### PR TITLE
Sandcat should be reverse-proxy aware

### DIFF
--- a/app/sand_api.py
+++ b/app/sand_api.py
@@ -2,6 +2,7 @@ import json
 from datetime import datetime
 
 from aiohttp import web
+from urllib.parse import urlparse
 
 
 class SandApi:
@@ -12,7 +13,9 @@ class SandApi:
 
     async def instructions(self, request):
         data = json.loads(self.agent_svc.decode_bytes(await request.read()))
-        data['server'] = '%s://%s' % (request.scheme, request.host)
+        url = urlparse(data['server'])
+        port = '443' if url.scheme == 'https' else 80
+        data['server'] = '%s://%s:%s' % (url.scheme, url.hostname, url.port if url.port else port)
         await self.agent_svc.handle_heartbeat(**data)
         instructions = await self.agent_svc.get_instructions(data['paw'])
         return web.Response(text=self.agent_svc.encode_string(instructions))


### PR DESCRIPTION
Sandcat should account for caldera being behind a reverse proxy (e.g. ssl plugin) and therefore shouldn't assume caldera's URL can be constructed from the request info.  Rather, it should construct the caldera URL from the agent's perspective, i.e. from the data the agent sends to the caldera server.