### PR TITLE
virts-434: making into go-module

### DIFF
--- a/gocat/contact/api.go
+++ b/gocat/contact/api.go
@@ -11,9 +11,9 @@ import (
 	"runtime"
 	"strings"
 
-	"../execute"
-	"../util"
-	"../output"
+	"gocat/execute"
+	"gocat/output"
+	"gocat/util"
 )
 
 const (

--- a/gocat/execute/execute.go
+++ b/gocat/execute/execute.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"time"
 
-	"../shellcode"
-	"../util"
+	"gocat/shellcode"
+	"gocat/util"
 )
 
 const (

--- a/gocat/go.mod
+++ b/gocat/go.mod
@@ -1,0 +1,3 @@
+module gocat
+
+go 1.12

--- a/gocat/sandcat.go
+++ b/gocat/sandcat.go
@@ -13,11 +13,11 @@ import (
 	"strconv"
 	"time"
 
-	"./contact"
-	"./execute"
-	"./util"
-	"./output"
-	"./privdetect"
+	"gocat/contact"
+	"gocat/execute"
+	"gocat/output"
+	"gocat/privdetect"
+	"gocat/util"
 )
 
 /*

--- a/gocat/shellcode/shellcode.go
+++ b/gocat/shellcode/shellcode.go
@@ -1,7 +1,7 @@
 package shellcode
 
 import (
-	"../util"
+	"gocat/util"
 )
 
 const (

--- a/gocat/shellcode/shellcode_darwin.go
+++ b/gocat/shellcode/shellcode_darwin.go
@@ -1,7 +1,7 @@
 package shellcode
 
 import (
-	"../output"
+	"gocat/output"
 )
 
 // Runner runner

--- a/gocat/shellcode/shellcode_linux.go
+++ b/gocat/shellcode/shellcode_linux.go
@@ -4,7 +4,7 @@ import (
 	"os/exec"
 	"strconv"
 	"syscall"
-	"../output"
+	"gocat/output"
 )
 
 // Runner runner

--- a/gocat/shellcode/shellcode_windows.go
+++ b/gocat/shellcode/shellcode_windows.go
@@ -4,7 +4,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"../util"
+	"gocat/util"
 )
 
 const (

--- a/gocat/util/proxy.go
+++ b/gocat/util/proxy.go
@@ -1,13 +1,13 @@
 package util 
 
 import (
+	"bytes"
 	"fmt"
+	"gocat/output"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"time"
-	"io/ioutil"
-	"bytes"
-	"../output"
 )
 
 //StartProxy creates an HTTP listener to forward traffic to server

--- a/gocat/util/utility.go
+++ b/gocat/util/utility.go
@@ -4,13 +4,13 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"io"
+	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 	"unicode"
-	"path/filepath"
-	"io"
-	"net/http"
 )
 
 // Encode base64 encodes bytes


### PR DESCRIPTION
Relative import paths are not "allowed" in GO and should not be used.  Go introduced "modules" that allow you to build projects outside of your $GOPATH.