### PR TITLE
virts-434d: updating command syscall attribute support per platform

### DIFF
--- a/gocat/execute/execute.go
+++ b/gocat/execute/execute.go
@@ -134,6 +134,7 @@ func runShellExecutor(executor string, platform string, command string) ([]byte,
 	status := SUCCESS_STATUS
 	var stdoutBuf, stderrBuf bytes.Buffer
 	cmd := buildCommandStatement(executor, platform, command)
+	cmd.SysProcAttr = getPlatformSysProcAttrs()
 	cmd.Stdout = &stdoutBuf
 	cmd.Stderr = &stderrBuf
 	err := cmd.Start()

--- a/gocat/execute/execute_darwin.go
+++ b/gocat/execute/execute_darwin.go
@@ -1,0 +1,7 @@
+package execute
+
+import "syscall"
+
+func getPlatformSysProcAttrs() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{}
+}

--- a/gocat/execute/execute_linux.go
+++ b/gocat/execute/execute_linux.go
@@ -1,0 +1,8 @@
+package execute
+
+import "syscall"
+
+func getPlatformSysProcAttrs() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{}
+}
+

--- a/gocat/execute/execute_windows.go
+++ b/gocat/execute/execute_windows.go
@@ -1,0 +1,7 @@
+package execute
+
+import "syscall"
+
+func getPlatformSysProcAttrs() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{HideWindow: true}
+}


### PR DESCRIPTION
This is needed to support window hiding when running the agent from rundll32 or service based approaches.

Eventually we can enable process attribute configuration to enable more flexibility when spawning child processes.