### PR TITLE
virts-434e: adding shared library compilation option to server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 .logs/*
 !.logs/.gitkeep
 .idea
+shared.h
+sandcat.h

--- a/app/sand_svc.py
+++ b/app/sand_svc.py
@@ -22,7 +22,7 @@ class SandService(BaseService):
 
     async def dynamically_compile_library(self, headers):
         name, platform = headers.get('file'), headers.get('platform')
-        if which('X86_64-w64-mingw32-gcc') is not None and platform == 'windows':
+        if which('go') is not None and which('X86_64-w64-mingw32-gcc') is not None and platform == 'windows':
             await self._compile_new_agent(platform=platform,
                                           headers=headers,
                                           compile_target_name=name.split('.')[0] + '_' + platform + '.go',

--- a/hook.py
+++ b/hook.py
@@ -9,7 +9,8 @@ address = '/plugin/sandcat/gui'
 async def enable(services):
     app = services.get('app_svc').application
     file_svc = services.get('file_svc')
-    await file_svc.add_special_payload('sandcat.go', SandService(services).dynamically_compile)
+    await file_svc.add_special_payload('sandcat.go', SandService(services).dynamically_compile_executable)
+    await file_svc.add_special_payload('shared.go', SandService(services).dynamically_compile_library)
     cat_gui_api = SandGuiApi(services=services)
     app.router.add_static('/sandcat', 'plugins/sandcat/static/', append_version=True)
     app.router.add_route('GET', '/plugin/sandcat/gui', cat_gui_api.splash)


### PR DESCRIPTION
This adds a split option for executables and libraries using mingw