### PR TITLE
Consistent navbar across splash pages

### DIFF
--- a/templates/sandcat.html
+++ b/templates/sandcat.html
@@ -10,7 +10,9 @@
     </head>
     <body>
     <center style="margin-bottom: 100px">
-        
+    <div class="navbar">
+        <a onclick="localStorage.setItem('intro', '1')" href="/">Home</a>
+        <a href="/logout" style="float:right">Logout</a>
         <div>
             <div id="sandcat-blocks" class="row-canvas">
                 <div class="section-profile">


### PR DESCRIPTION
The sandcat splash page currently lacks the navbar used on other pages. 

It may make senses not to populate the navbar on the sandcat splash page with all tabs/sub-tabs. 
However, having it there for users to click home after running a command seems intuitive. 

This PR only includes adding the home button and logout. 
