### PR TITLE
shared_windows.go small bug fix

### DIFF
--- a/gocat/shared/shared_windows.go
+++ b/gocat/shared/shared_windows.go
@@ -18,7 +18,7 @@ var (
 //export VoidFunc
 func VoidFunc() {
 	c2Config := map[string]string{"c2Name": c2Name, "c2Key": c2Key}
-	core.Core(defaultServer, defaultGroup, defaultSleep, 0, defaultExeName, []string{"psh","cmd"}, c2Config, false)
+	core.Core(defaultServer, defaultGroup, defaultSleep, 0, []string{"psh","cmd"}, c2Config, false)
 }
 
 func main() {}


### PR DESCRIPTION
fixing shared_windows.go core.Core() call - there was an extra field