### PR TITLE
Remove watchdog parameter from shared.go core call

### DIFF
--- a/gocat/shared/shared.go
+++ b/gocat/shared/shared.go
@@ -17,7 +17,7 @@ var (
 //export VoidFunc
 func VoidFunc() {
 	c2Config := map[string]string{"c2Name": c2Name, "c2Key": c2Key}
-	core.Core(server, 0, nil, c2Config, false, 0)
+	core.Core(server, 0, nil, c2Config, false)
 }
 
 func main() {}


### PR DESCRIPTION
Due to changes in https://github.com/mitre/sandcat/pull/211, the watchdog argument in `shared.go/core.Core` call needs to be removed for successful compliation.