### PR TITLE
Fix agent runtime errors

### DIFF
--- a/gocat/core/core.go
+++ b/gocat/core/core.go
@@ -5,29 +5,30 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"os/exec"
 	"os/user"
+	"path/filepath"
 	"reflect"
 	"runtime"
 	"strings"
 	"time"
-	"path/filepath"
 
 	"../contact"
 	"../execute"
-	"../util"
 	"../output"
 	"../privdetect"
+	"../util"
 )
 
 func runAgent(coms contact.Contact, profile map[string]interface{}) {
-    watchdog := 0
+	watchdog := 0
 	checkin := time.Now()
 	for {
 		beacon := coms.GetInstructions(profile)
 		if len(beacon) != 0 {
 			profile["paw"] = beacon["paw"]
 			checkin = time.Now()
-		} 
+		}
 		if beacon["instructions"] != nil && len(beacon["instructions"].([]interface{})) > 0 {
 			cmds := reflect.ValueOf(beacon["instructions"])
 			for i := 0; i < cmds.Len(); i++ {
@@ -52,13 +53,17 @@ func runAgent(coms contact.Contact, profile map[string]interface{}) {
 
 func buildProfile(server string, group string, executors []string, privilege string, c2 string) map[string]interface{} {
 	host, _ := os.Hostname()
-	user, _ := user.Current()
-
 	profile := make(map[string]interface{})
 	profile["server"] = server
 	profile["group"] = group
 	profile["host"] = host
-	profile["username"] = user.Username
+	user, err := user.Current()
+	if err != nil {
+		output.VerbosePrint(err.Error())
+		profile["username"], err = exec.Command("whoami").CombinedOutput()
+	} else {
+		profile["username"] = user.Username
+	}
 	profile["architecture"] = runtime.GOARCH
 	profile["platform"] = runtime.GOOS
 	profile["location"] = os.Args[0]
@@ -102,11 +107,13 @@ func Core(server string, group string, delay int, executors []string, c2 map[str
 
 	profile := buildProfile(server, group, executors, privilege, c2["c2Name"])
 	util.Sleep(float64(delay))
-
 	for {
 		coms := chooseCommunicationChannel(profile, c2)
+		output.VerbosePrint(fmt.Sprint(coms))
 		if coms != nil {
-			for { runAgent(coms, profile) }
+			for {
+				runAgent(coms, profile)
+			}
 		}
 		util.Sleep(300)
 	}

--- a/gocat/core/core.go
+++ b/gocat/core/core.go
@@ -59,7 +59,6 @@ func buildProfile(server string, group string, executors []string, privilege str
 	profile["host"] = host
 	user, err := user.Current()
 	if err != nil {
-		output.VerbosePrint(err.Error())
 		profile["username"], err = exec.Command("whoami").CombinedOutput()
 	} else {
 		profile["username"] = user.Username
@@ -109,7 +108,6 @@ func Core(server string, group string, delay int, executors []string, c2 map[str
 	util.Sleep(float64(delay))
 	for {
 		coms := chooseCommunicationChannel(profile, c2)
-		output.VerbosePrint(fmt.Sprint(coms))
 		if coms != nil {
 			for {
 				runAgent(coms, profile)

--- a/gocat/util/utility.go
+++ b/gocat/util/utility.go
@@ -4,13 +4,13 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"io"
+	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 	"unicode"
-	"path/filepath"
-	"io"
-	"net/http"
 )
 
 // Encode base64 encodes bytes
@@ -108,7 +108,7 @@ func removeWhiteSpace(input string) string {
 }
 
 func EvaluateWatchdog(lastcheckin time.Time, watchdog int) {
-	if watchdog >0 && float64(time.Now().Sub(lastcheckin).Minutes()) > float64(watchdog){
+	if watchdog > 0 && float64(time.Now().Sub(lastcheckin).Minutes()) > float64(watchdog) {
 		StopProcess(os.Getpid())
 	}
 }


### PR DESCRIPTION
`os/user` will error out if a Windows user's profile does not exist on the machine which will crash the agent when building the profile.

Adds a workaround for this issue by checking if an error is returned from the `user.Current()` call and making a command call directly to `whoami`.