### PR TITLE
Include profile in C2RequirementsMet for contact interface

### DIFF
--- a/gocat/contact/api.go
+++ b/gocat/contact/api.go
@@ -85,7 +85,7 @@ func (contact API) RunInstruction(command map[string]interface{}, profile map[st
 }
 
 //C2RequirementsMet determines if sandcat can use the selected comm channel
-func (contact API) C2RequirementsMet(criteria map[string]string) bool {
+func (contact API) C2RequirementsMet(profile map[string]interface{}, criteria map[string]string) bool {
 	output.VerbosePrint(fmt.Sprintf("Beacon API=%s", apiBeacon))
 	return true
 }

--- a/gocat/contact/contact.go
+++ b/gocat/contact/contact.go
@@ -10,7 +10,7 @@ type Contact interface {
 	GetInstructions(profile map[string]interface{}) map[string]interface{}
 	GetPayloadBytes(payload string, server string, uniqueID string, platform string, writeToDisk bool) (string, []byte)
 	RunInstruction(command map[string]interface{}, profile map[string]interface{}, payloads []string)
-	C2RequirementsMet(criteria map[string]string) bool
+	C2RequirementsMet(profile map[string]interface{}, criteria map[string]string) bool
 	SendExecutionResults(profile map[string]interface{}, result map[string]interface{})
 }
 

--- a/gocat/core/core.go
+++ b/gocat/core/core.go
@@ -96,17 +96,17 @@ func buildProfile(server string, group string, executors []string, privilege str
 
 func chooseCommunicationChannel(profile map[string]interface{}, c2Config map[string]string) contact.Contact {
 	coms, _ := contact.CommunicationChannels[c2Config["c2Name"]]
-	if !validC2Configuration(coms, c2Config) {
+	if !validC2Configuration(profile, coms, c2Config) {
 		output.VerbosePrint("[-] Invalid C2 Configuration! Defaulting to HTTP")
 		coms, _ = contact.CommunicationChannels["HTTP"]
 	}
 	return coms
 }
 
-func validC2Configuration(coms contact.Contact, c2Config map[string]string) bool {
+func validC2Configuration(profile map[string]interface{}, coms contact.Contact, c2Config map[string]string) bool {
 	if strings.EqualFold(c2Config["c2Name"], c2Config["c2Name"]) {
 		if _, valid := contact.CommunicationChannels[c2Config["c2Name"]]; valid {
-			return coms.C2RequirementsMet(c2Config)
+			return coms.C2RequirementsMet(profile, c2Config)
 		}
 	}
 	return false


### PR DESCRIPTION
Add profile parameter to C2RequirementsMet function.  The goal is to use this method in the future to update the profile's server to adapt to any C2 requirements - for instance, if the server is just a hostname and the contact method is SMB piping, the C2RequirementsMet implementation for SMB pipes can update the profile's server to the hostname + default pipe path.