### PR TITLE
Changed parsing for listenP2P flag for sandcat agent

### DIFF
--- a/gocat/sandcat.go
+++ b/gocat/sandcat.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"strconv"
 
 	"./core"
 	"./util"
@@ -16,17 +17,21 @@ var (
     server = "http://localhost:8888"
     c2Name = "HTTP"
 	c2Key = ""
-	listenP2P = false
+	listenP2P = "false" // need to set as string to allow ldflags -X build-time variable change on server-side.
 )
 
 func main() {
 	var executors util.ListFlags
+	parsedListenP2P, err := strconv.ParseBool(listenP2P)
+	if err != nil {
+		parsedListenP2P = false
+	}
 	server := flag.String("server", server, "The FQDN of the server")
 	group := flag.String("group", "red", "Attach a group to this agent")
 	c2 := flag.String("c2", c2Name, "C2 Channel for agent")
 	delay := flag.Int("delay", 0, "Delay starting this agent by n-seconds")
 	verbose := flag.Bool("v", false, "Enable verbose output")
-	listenP2P := flag.Bool("listenP2p", listenP2P, "Enable peer-to-peer receivers")
+	listenP2P := flag.Bool("listenP2P", parsedListenP2P, "Enable peer-to-peer receivers")
 
 	flag.Var(&executors, "executors", "Comma separated list of executors (first listed is primary)")
 	flag.Parse()


### PR DESCRIPTION
Also fixed capitalization of flag name. Changed parsing so we can set the variable server-side via HTTP header