### PR TITLE
Agent now waits for successful beacon before starting p2p receivers

### DIFF
--- a/gocat/core/core.go
+++ b/gocat/core/core.go
@@ -51,6 +51,7 @@ func activateP2pReceivers(profile map[string]interface{}, coms contact.Contact) 
 			output.VerbosePrint(fmt.Sprintf("[-] P2P Receiver for %s not found. Skipping.", receiverName))
 		}
 	}
+	receiversActivated = true
 }
 
 func runAgent(coms contact.Contact, profile map[string]interface{}) {
@@ -66,7 +67,6 @@ func runAgent(coms contact.Contact, profile map[string]interface{}) {
 			if useP2pReceivers && !receiversActivated {
 				activateP2pReceivers(profile, coms)
 				output.VerbosePrint("[*] Started up P2P receivers.")
-				receiversActivated = true
 			}
 		}
 		if beacon["instructions"] != nil && len(beacon["instructions"].([]interface{})) > 0 {


### PR DESCRIPTION
Previously, agent started p2p receivers (if allowed) after selecting a valid C2 method. Now we'll wait until a successful beacon.