### PR TITLE
Add sandcat binaries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 .idea
 shared.h
 sandcat.h
+payloads/sandcat.go-*


### PR DESCRIPTION
Adds `payloads/sandcat.go-*` to `.gitignore` to prevent accidental updates to static binaries in all future pushes. This makes it so that the addition of sandcat binaries to the repository are deliberate updates.