### PR TITLE
VIRTS-762/896 When specified, server will include online peers at build-time for agent to use in p2p comms

### DIFF
--- a/app/sand_svc.py
+++ b/app/sand_svc.py
@@ -55,7 +55,7 @@ class SandService(BaseService):
                                               output_name=name,
                                               buildmode='--buildmode=c-shared',
                                               **compile_options[platform],
-                                              flag_params=('server', 'c2'),
+                                              flag_params=('server', 'c2', 'fetchPeers'),
                                               extension_names=extension_names)
         return '%s-%s' % (name, platform), self.generate_name()
 
@@ -102,7 +102,8 @@ class SandService(BaseService):
                     self._remove_module_files_from_sandcat(module)
 
     async def _compile_new_agent(self, platform, headers, compile_target_name, output_name, buildmode='',
-                                 extldflags='', cflags='', flag_params=('server', 'c2'), extension_names=None):
+                                 extldflags='', cflags='', flag_params=('server', 'c2', 'fetchPeers'),
+                                 extension_names=None):
         """Compile sandcat agent using specified parameters. Will also include any requested extension modules."""
 
         plugin, file_path = await self.file_svc.find_file_path(compile_target_name)
@@ -111,6 +112,8 @@ class SandService(BaseService):
             if param in headers:
                 if param == 'c2':
                     ldflags.append('-X main.%s=%s' % (await self._get_c2_config(headers[param])))
+                elif param == 'fetchPeers':
+                    ldflags.append('-X main.%s=%s' % ('onlineHosts', ','.join([agent.host for agent in await self.data_svc.locate('agents')])))
                 else:
                     ldflags.append('-X main.%s=%s' % (param, headers[param]))
         output = 'plugins/%s/payloads/%s-%s' % (plugin, output_name, platform)

--- a/app/sand_svc.py
+++ b/app/sand_svc.py
@@ -113,7 +113,7 @@ class SandService(BaseService):
                 if param == 'c2':
                     ldflags.append('-X main.%s=%s' % (await self._get_c2_config(headers[param])))
                 elif param == 'fetchPeers' and headers.get(param, "").lower() == "true":
-                    ldflags.append('-X main.%s=%s' % ('onlineHosts', ','.join([agent.host for agent in await self.data_svc.locate('agents')])))
+                    ldflags.append('-X main.%s=%s' % ('onlineHosts', ','.join([agent.host for agent in await self.data_svc.locate('agents') if agent.trusted])))
                 else:
                     ldflags.append('-X main.%s=%s' % (param, headers[param]))
         output = 'plugins/%s/payloads/%s-%s' % (plugin, output_name, platform)

--- a/app/sand_svc.py
+++ b/app/sand_svc.py
@@ -112,7 +112,7 @@ class SandService(BaseService):
             if param in headers:
                 if param == 'c2':
                     ldflags.append('-X main.%s=%s' % (await self._get_c2_config(headers[param])))
-                elif param == 'fetchPeers':
+                elif param == 'fetchPeers' and headers.get(param, "").lower() == "true":
                     ldflags.append('-X main.%s=%s' % ('onlineHosts', ','.join([agent.host for agent in await self.data_svc.locate('agents')])))
                 else:
                     ldflags.append('-X main.%s=%s' % (param, headers[param]))

--- a/gocat/sandcat.go
+++ b/gocat/sandcat.go
@@ -18,6 +18,7 @@ var (
     c2Name = "HTTP"
 	c2Key = ""
 	listenP2P = "false" // need to set as string to allow ldflags -X build-time variable change on server-side.
+	onlineHosts = "" // comma-separated list of online agents to try p2p comms with.
 )
 
 func main() {
@@ -37,5 +38,5 @@ func main() {
 	flag.Parse()
 	
 	c2Config := map[string]string{"c2Name": *c2, "c2Key": c2Key}
-	core.Core(*server, *group, *delay, executors, c2Config, *listenP2P, *verbose)
+	core.Core(*server, *group, *delay, executors, c2Config, *listenP2P, onlineHosts, *verbose)
 }


### PR DESCRIPTION
To support VIRTS-762 and VIRTS-896.
Next PR will have the sandcat agent actually switch to using one of the online peers for comms if communication with the c2 doesn't work. To have the server send over the peers, include the "fetchPeers" http header with "true" value