### PR TITLE
making gocat into a go module 

### DIFF
--- a/app/sand_svc.py
+++ b/app/sand_svc.py
@@ -113,13 +113,15 @@ class SandService(BaseService):
                     ldflags.append('-X main.%s=%s' % (await self._get_c2_config(headers[param])))
                 else:
                     ldflags.append('-X main.%s=%s' % (param, headers[param]))
-        output = 'plugins/%s/payloads/%s-%s' % (plugin, output_name, platform)
         ldflags.append(extldflags)
+        output = '../payloads/%s-%s' % (output_name, platform)
 
         # Load extensions and compile.
         installed_extensions = await self._install_gocat_extensions(extension_names)
         self.file_svc.log.debug('Dynamically compiling %s' % compile_target_name)
-        await self.file_svc.compile_go(platform, output, file_path, buildmode=buildmode, ldflags=' '.join(ldflags), cflags=cflags)
+        build_path, build_file = os.path.split(file_path)
+        await self.file_svc.compile_go(platform, output, build_file, buildmode=buildmode, ldflags=' '.join(ldflags),
+                                       cflags=cflags, build_dir=build_path)
 
         # Remove extension files.
         if installed_extensions:

--- a/gocat-extensions/contact/gist.go
+++ b/gocat-extensions/contact/gist.go
@@ -11,9 +11,9 @@ import (
 	"strconv"
 	"time"
 
-	"../executors/execute"
-	"../output"
-	"../util"
+	"github.com/mitre/sandcat/gocat/executors/execute"
+	"github.com/mitre/sandcat/gocat/output"
+	"github.com/mitre/sandcat/gocat/util"
 )
 
 const (

--- a/gocat/contact/api.go
+++ b/gocat/contact/api.go
@@ -8,9 +8,9 @@ import (
 	"net/http"
 	"path/filepath"
 
-	"../executors/execute"
-	"../output"
-	"../util"
+	"github.com/mitre/sandcat/gocat/executors/execute"
+	"github.com/mitre/sandcat/gocat/output"
+	"github.com/mitre/sandcat/gocat/util"
 )
 
 var (

--- a/gocat/core/core.go
+++ b/gocat/core/core.go
@@ -13,15 +13,15 @@ import (
 	"strings"
 	"time"
 
-	"../contact"
-	"../proxy"
-	"../executors/execute"
-	"../output"
-	"../privdetect"
-	"../util"
+	"github.com/mitre/sandcat/gocat/contact"
+	"github.com/mitre/sandcat/gocat/proxy"
+	"github.com/mitre/sandcat/gocat/executors/execute"
+	"github.com/mitre/sandcat/gocat/output"
+	"github.com/mitre/sandcat/gocat/privdetect"
+	"github.com/mitre/sandcat/gocat/util"
 
-	_ "../executors/shellcode" // necessary to initialize all submodules
-	_ "../executors/shells"    // necessary to initialize all submodules
+	_ "github.com/mitre/sandcat/gocat/executors/shellcode" // necessary to initialize all submodules
+	_ "github.com/mitre/sandcat/gocat/executors/shells"    // necessary to initialize all submodules
 )
 
 var useP2pReceivers = false

--- a/gocat/executors/execute/execute.go
+++ b/gocat/executors/execute/execute.go
@@ -1,7 +1,7 @@
 package execute
 
 import (
-	"../../util"
+	"github.com/mitre/sandcat/gocat/util"
 	"fmt"
 	"strings"
 )

--- a/gocat/executors/shellcode/shellcode.go
+++ b/gocat/executors/shellcode/shellcode.go
@@ -5,8 +5,8 @@ package shellcode
 import (
 	"runtime"
 
-	"../execute"
-	"../../util"
+	"github.com/mitre/sandcat/gocat/executors/execute"
+	"github.com/mitre/sandcat/gocat/util"
 )
 
 type Shellcode struct {

--- a/gocat/executors/shellcode/shellcode_linux.go
+++ b/gocat/executors/shellcode/shellcode_linux.go
@@ -4,7 +4,7 @@ import (
 	"os/exec"
 	"strconv"
 	"syscall"
-	"../../output"
+	"github.com/mitre/sandcat/gocat/output"
 )
 
 // Runner runner

--- a/gocat/executors/shellcode/shellcode_windows.go
+++ b/gocat/executors/shellcode/shellcode_windows.go
@@ -4,8 +4,8 @@ import (
 	"syscall"
 	"unsafe"
 
-	"../execute"
-	"../../util"
+	"github.com/mitre/sandcat/gocat/executors/execute"
+	"github.com/mitre/sandcat/gocat/util"
 )
 
 const (

--- a/gocat/executors/shells/cmd.go
+++ b/gocat/executors/shells/cmd.go
@@ -3,7 +3,7 @@
 package shells
 
 import (
-	"../execute"
+	"github.com/mitre/sandcat/gocat/executors/execute"
 	"os/exec"
 )
 

--- a/gocat/executors/shells/osascript.go
+++ b/gocat/executors/shells/osascript.go
@@ -3,7 +3,7 @@
 package shells
 
 import (
-	"../execute"
+	"github.com/mitre/sandcat/gocat/executors/execute"
 	"os/exec"
 )
 

--- a/gocat/executors/shells/powershell.go
+++ b/gocat/executors/shells/powershell.go
@@ -3,7 +3,7 @@
 package shells
 
 import (
-	"../execute"
+	"github.com/mitre/sandcat/gocat/executors/execute"
 	"os/exec"
 )
 

--- a/gocat/executors/shells/powershell_core.go
+++ b/gocat/executors/shells/powershell_core.go
@@ -3,7 +3,7 @@
 package shells
 
 import (
-	"../execute"
+	"github.com/mitre/sandcat/gocat/executors/execute"
 	"os/exec"
 	"runtime"
 )

--- a/gocat/executors/shells/shell.go
+++ b/gocat/executors/shells/shell.go
@@ -1,7 +1,7 @@
 package shells
 
 import (
-	"../execute"
+	"github.com/mitre/sandcat/gocat/executors/execute"
 	"os/exec"
 )
 

--- a/gocat/executors/shells/shells_shared.go
+++ b/gocat/executors/shells/shells_shared.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"time"
 
-	"../execute"
-	"../../output"
+	"github.com/mitre/sandcat/gocat/executors/execute"
+	"github.com/mitre/sandcat/gocat/output"
 )
 
 func checkExecutorInPath(path string) bool {

--- a/gocat/go.mod
+++ b/gocat/go.mod
@@ -1,0 +1,3 @@
+module github.com/mitre/sandcat/gocat
+
+go 1.13

--- a/gocat/proxy/httpproxy.go
+++ b/gocat/proxy/httpproxy.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"io/ioutil"
-	"../output"
-	"../contact"
+	"github.com/mitre/sandcat/gocat/output"
+	"github.com/mitre/sandcat/gocat/contact"
 )
 
 //HttpReceiver forwards data received from HTTP requests to the upstream server via HTTP. Implements the P2pReceiver interface.

--- a/gocat/proxy/proxy.go
+++ b/gocat/proxy/proxy.go
@@ -2,7 +2,7 @@ package proxy
 
 import (
     "encoding/json"
-    "../contact"
+    "github.com/mitre/sandcat/gocat/contact"
 )
 
 // Define MessageType values for P2pMessage

--- a/gocat/sandcat.go
+++ b/gocat/sandcat.go
@@ -4,8 +4,8 @@ import (
 	"flag"
 	"strconv"
 
-	"./core"
-	"./util"
+	"github.com/mitre/sandcat/gocat/core"
+	"github.com/mitre/sandcat/gocat/util"
 )
 
 /*

--- a/gocat/sandcat.go
+++ b/gocat/sandcat.go
@@ -2,10 +2,9 @@ package main
 
 import (
 	"flag"
-	"strconv"
-
 	"github.com/mitre/sandcat/gocat/core"
 	"github.com/mitre/sandcat/gocat/util"
+	"strconv"
 )
 
 /*

--- a/gocat/shared/shared.go
+++ b/gocat/shared/shared.go
@@ -4,7 +4,7 @@ package main
 
 import "C"
 import (
-	"../core"
+	"github.com/mitre/sandcat/gocat/core"
 )
 
 var (

--- a/gocat/util/proxy.go
+++ b/gocat/util/proxy.go
@@ -7,7 +7,7 @@ import (
 	"time"
 	"io/ioutil"
 	"bytes"
-	"../output"
+	"github.com/mitre/sandcat/gocat/output"
 )
 
 //StartProxy creates an HTTP listener to forward traffic to server


### PR DESCRIPTION
relative import paths are removed.  This should fix the issue of trying to set variables in subpackages via LDFLAGs as the linker will know to inspect just the local module package to render variables.

Ideally this "trims down" the number of parameters that need to be passed from the Sandcat file and allows for more targeted variable addition from server.

Needs testing