### PR TITLE
Fix dynamic compliation vars

### DIFF
--- a/app/sand_svc.py
+++ b/app/sand_svc.py
@@ -55,7 +55,7 @@ class SandService(BaseService):
                                               output_name=name,
                                               buildmode='--buildmode=c-shared',
                                               **compile_options[platform],
-                                              flag_params=('server', 'c2'),
+                                              flag_params=('server', 'group', 'listenP2P', 'c2'),
                                               extension_names=extension_names)
         return '%s-%s' % (name, platform), self.generate_name()
 
@@ -102,7 +102,7 @@ class SandService(BaseService):
                     self._remove_module_files_from_sandcat(module)
 
     async def _compile_new_agent(self, platform, headers, compile_target_name, output_name, buildmode='',
-                                 extldflags='', cflags='', flag_params=('server', 'c2'), extension_names=None):
+                                 extldflags='', cflags='', flag_params=('server', 'group', 'listenP2P', 'c2'), extension_names=None):
         """Compile sandcat agent using specified parameters. Will also include any requested extension modules."""
 
         plugin, file_path = await self.file_svc.find_file_path(compile_target_name)

--- a/gocat/sandcat.go
+++ b/gocat/sandcat.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"flag"
+	"strconv"
+
 	"github.com/mitre/sandcat/gocat/core"
 	"github.com/mitre/sandcat/gocat/util"
-	"strconv"
 )
 
 /*
@@ -12,10 +13,11 @@ These default  values can be overridden during linking - server, group, and slee
 with command-line arguments at runtime.
 */
 var (
-    key = "JWHQZM9Z4HQOYICDHW4OCJAXPPNHBA"
-    server = "http://localhost:8888"
-    c2Name = "HTTP"
-	c2Key = ""
+	key       = "JWHQZM9Z4HQOYICDHW4OCJAXPPNHBA"
+	server    = "http://localhost:8888"
+	group     = "red"
+	c2Name    = "HTTP"
+	c2Key     = ""
 	listenP2P = "false" // need to set as string to allow ldflags -X build-time variable change on server-side.
 )
 
@@ -26,7 +28,7 @@ func main() {
 		parsedListenP2P = false
 	}
 	server := flag.String("server", server, "The FQDN of the server")
-	group := flag.String("group", "red", "Attach a group to this agent")
+	group := flag.String("group", group, "Attach a group to this agent")
 	c2 := flag.String("c2", c2Name, "C2 Channel for agent")
 	delay := flag.Int("delay", 0, "Delay starting this agent by n-seconds")
 	verbose := flag.Bool("v", false, "Enable verbose output")
@@ -34,7 +36,7 @@ func main() {
 
 	flag.Var(&executors, "executors", "Comma separated list of executors (first listed is primary)")
 	flag.Parse()
-	
+
 	c2Config := map[string]string{"c2Name": *c2, "c2Key": c2Key}
 	core.Core(*server, *group, *delay, executors, c2Config, *listenP2P, *verbose)
 }

--- a/gocat/shared/shared.go
+++ b/gocat/shared/shared.go
@@ -4,6 +4,8 @@ package main
 
 import "C"
 import (
+	"strconv"
+
 	"github.com/mitre/sandcat/gocat/core"
 )
 
@@ -11,15 +13,17 @@ var (
 	key       = "JWHQZM9Z4HQOYICDHW4OCJAXPPNHBA"
 	server    = "http://localhost:8888"
 	group     = "red"
-	listenP2P = false
+	listenP2P = "false"
 	c2Name    = "HTTP"
 	c2Key     = ""
 )
 
 //export VoidFunc
 func VoidFunc() {
+	parsedListenP2P, _ := strconv.ParseBool(listenP2P)
+
 	c2Config := map[string]string{"c2Name": c2Name, "c2Key": c2Key}
-	core.Core(server, group, 0, nil, c2Config, listenP2P, false)
+	core.Core(server, group, 0, nil, c2Config, parsedListenP2P, false)
 }
 
 func main() {}

--- a/payloads/sandcat-elfload.py
+++ b/payloads/sandcat-elfload.py
@@ -7,11 +7,11 @@ import requests
 # pull environment variables for server, group, and process name
 proc_name = os.getenv('SC_PROC_NAME', 'sandcat')
 server = os.getenv('SC_DEFAULTSERVER', 'http://localhost:8888')
-group = os.getenv('SC_DEFAULTGROUP', 'my_group')
+group = os.getenv('SC_DEFAULTGROUP', 'red')
 
 print("{} {} {}".format(proc_name, server, group))
 
-headers = dict(file='sandcat.go', platform='linux', server=server, defaultGroup=group)
+headers = dict(file='sandcat.go', platform='linux', server=server, group=group)
 r = requests.get('%s/file/download' % server, headers=headers, stream=True)
 print(r.status_code)
 if r.status_code == 200:

--- a/payloads/sandcat-inmem.sh
+++ b/payloads/sandcat-inmem.sh
@@ -4,7 +4,7 @@ set -e
 
 export SC_PROC_NAME=${SC_PROC_NAME:-'sandcat'}
 export SC_DEFAULTSERVER=${SC_DEFAULTSERVER:-'http://localhost:8888'}
-export SC_DEFAULTGROUP=${SC_DEFAULTGROUP:-'my_group'}
+export SC_DEFAULTGROUP=${SC_DEFAULTGROUP:-'red'}
 
 declare -a binaries=("python3" "python" "perl")
 


### PR DESCRIPTION
* Re-add group parameter to `flag_params` for in-memory agent functionality in situations where it cannot be provided via command-line argument.
* Add listenP2P flag to shared agent with ability to change on compilation.