### PR TITLE
VIRTS-1153 Cleaned up module installation code

### DIFF
--- a/app/extensions/execute/shellcode/shellcode.py
+++ b/app/extensions/execute/shellcode/shellcode.py
@@ -9,8 +9,6 @@ class Shellcode(Extension):
 
     def __init__(self):
         super().__init__([
-            ('shellcode.go', 'execute/shellcode'),
-            ('shellcode_linux.go', 'execute/shellcode'),
-            ('shellcode_windows.go', 'execute/shellcode'),
+            ('*', 'execute/shellcode'),
         ])
         self.dependencies = []

--- a/app/sand_svc.py
+++ b/app/sand_svc.py
@@ -64,8 +64,9 @@ class SandService(BaseService):
         return '%s-%s' % (name, platform), self.generate_name()
 
     async def load_sandcat_extension_modules(self):
-        """Recursively searches the app/extensions folder for valid extension modules."""
-
+        """
+        Recursively searches the app/extensions folder for valid extension modules.
+        """
         for root, dirs, files in os.walk(os.path.join(self.sandcat_dir, 'app', 'extensions')):
             files = [f for f in files if not f[0] == '.' and not f[0] == "_"]
             dirs[:] = [d for d in dirs if not d[0] == '.' and not d[0] == "_"]
@@ -91,8 +92,9 @@ class SandService(BaseService):
 
     async def _compile_new_agent(self, platform, headers, compile_target_name, output_name, buildmode='',
                                  extldflags='', cflags='', flag_params=default_flag_params, extension_names=None):
-        """Compile sandcat agent using specified parameters. Will also include any requested extension modules."""
-
+        """
+        Compile sandcat agent using specified parameters. Will also include any requested extension modules.
+        """
         plugin, file_path = await self.file_svc.find_file_path(compile_target_name)
         ldflags = ['-s', '-w', '-X main.key=%s' % (self._generate_key(),)]
         for param in flag_params:
@@ -116,26 +118,30 @@ class SandService(BaseService):
         await self._uninstall_gocat_extensions(installed_extensions)
 
     async def _install_gocat_extensions(self, extension_names):
-        """Given a list of extension names, will copy the required files for each extension from the gocat-extensions
-        subdirectory into the gocat subdirectory."""
+        """
+        Given a list of extension names, copies the required files for each extension from the gocat-extensions
+        subdirectory into the gocat subdirectory.
+        """
         if which('go') is not None and extension_names:
             self.log.debug('Installing gocat extension modules: %s' % ', '.join(extension_names))
             return [name for name in extension_names if await self._attempt_module_copy(name=name)]
         return []
 
     async def _uninstall_gocat_extensions(self, extension_names):
-        """Given a list of extension names, will remove the required files for each extension from the gocat
-        subdirectory."""
-
+        """
+        Given a list of extension names, removes the required files for each extension from the gocat
+        subdirectory.
+        """
         if which('go') is not None and extension_names:
             self.log.debug('Cleaning up files for gocat extension modules %s' % ', '.join(extension_names))
             for extension_name in extension_names:
                 self.sandcat_extensions[extension_name].remove_module_files(base_dir=self.sandcat_dir)
 
     async def _load_extension_module(self, root, file):
-        """Give the file path and file name for the extension module file, will return the extension
-        module object. Helper method for _fetch_extension_module."""
-
+        """
+        Given the file path and file name for the extension module file, returns the extension
+        module object.
+        """
         module = os.path.join(root, file.split('.')[0]).replace(os.path.sep, '.')
         try:
             # Module's "load" method will return the extension module object.
@@ -144,8 +150,9 @@ class SandService(BaseService):
             self.log.error('Error loading extension=%s, %s' % (module, e))
 
     async def _attempt_module_copy(self, name):
-        """Attempts to copy the module files. Returns True upon success, False otherwise."""
-
+        """
+        Attempts to copy the module files. Returns True upon success, False otherwise.
+        """
         module = self.sandcat_extensions.get(name)
         if module:
             try:

--- a/app/sand_svc.py
+++ b/app/sand_svc.py
@@ -77,8 +77,6 @@ class SandService(BaseService):
                     else:
                         self.log.error('Failed to fulfill dependencies for module %s' % module)
 
-
-
     """ PRIVATE """
 
     @staticmethod

--- a/app/sand_svc.py
+++ b/app/sand_svc.py
@@ -72,10 +72,12 @@ class SandService(BaseService):
             for file in files:
                 module = await self._load_extension_module(root, file)
                 if module:
-                    if module.check_go_dependencies():
+                    if module.check_go_dependencies() or module.install_dependencies():
                         self.sandcat_extensions[file.split('.')[0]] = module
                     else:
-                        module.install_dependencies()
+                        self.log.error('Failed to fulfill dependencies for module %s' % module)
+
+
 
     """ PRIVATE """
 
@@ -149,10 +151,9 @@ class SandService(BaseService):
         module = self.sandcat_extensions.get(name)
         if module:
             try:
-                module.copy_module_files(base_dir=self.sandcat_dir)
-                return True
+                return module.copy_module_files(base_dir=self.sandcat_dir)
             except Exception as e:
-                self.log.error('Copy failed: %s' % e)
+                self.log.error('Error copying files for module %s: %s' % (module, e))
         else:
             self.log.error('Module %s not found' % name)
         return False

--- a/app/sand_svc.py
+++ b/app/sand_svc.py
@@ -3,9 +3,11 @@ import pathlib
 import random
 import string
 from importlib import import_module
-from shutil import copyfile, which
+from shutil import which
 
 from app.utility.base_service import BaseService
+
+default_flag_params = ('server', 'group', 'listenP2P', 'c2')
 
 
 class SandService(BaseService):
@@ -17,6 +19,7 @@ class SandService(BaseService):
         self.app_svc = services.get('app_svc')
         self.log = self.create_logger('sand_svc')
         self.sandcat_dir = os.path.relpath(os.path.join('plugins', 'sandcat'))
+        self.sandcat_extensions = dict()
 
     async def dynamically_compile_executable(self, headers):
         # HTTP headers will specify the file name, platform, and comma-separated list of extension modules to include.
@@ -56,9 +59,23 @@ class SandService(BaseService):
                                               output_name=name,
                                               buildmode='--buildmode=c-shared',
                                               **compile_options[platform],
-                                              flag_params=('server', 'group', 'listenP2P', 'c2'),
+                                              flag_params=default_flag_params,
                                               extension_names=extension_names)
         return '%s-%s' % (name, platform), self.generate_name()
+
+    async def load_sandcat_extension_modules(self):
+        """Recursively searches the app/extensions folder for valid extension modules."""
+
+        for root, dirs, files in os.walk(os.path.join(self.sandcat_dir, 'app', 'extensions')):
+            files = [f for f in files if not f[0] == '.' and not f[0] == "_"]
+            dirs[:] = [d for d in dirs if not d[0] == '.' and not d[0] == "_"]
+            for file in files:
+                module = await self._load_extension_module(root, file)
+                if module:
+                    if module.check_go_dependencies():
+                        self.sandcat_extensions[file.split('.')[0]] = module
+                    else:
+                        module.install_dependencies()
 
     """ PRIVATE """
 
@@ -72,38 +89,8 @@ class SandService(BaseService):
                 return 'c2Key', c2.retrieve_config()
         return '', ''
 
-    async def _install_gocat_extensions(self, extension_names):
-        """Given a list of extension names, will copy the required files for each extension from the gocat-extensions
-        subdirectory into the gocat subdirectory."""
-
-        installed_extensions = []
-        if which('go') is not None and extension_names:
-            self.log.debug('Installing gocat extension modules: %s' % ', '.join(extension_names))
-            for extension_name in extension_names:
-                module = self._fetch_extension_module(extension_name)
-                if module:
-                    if module.check_go_dependencies():
-                        self.log.debug('Fetched extension module %s' % extension_name)
-                        self._copy_module_files_to_sandcat(module)
-                        installed_extensions.append(extension_name)
-                    else:
-                        self.log.error('Dependencies not satisfied for extension %s' % extension_name)
-                else:
-                    self.log.error("Failed to fetch extension %s" % extension_name)
-        return installed_extensions
-
-    async def _uninstall_gocat_extensions(self, extension_names):
-        """Given a list of extension names, will remove the required files for each extension from the gocat
-        subdirectory."""
-
-        if which('go') is not None and extension_names:
-            for extension_name in extension_names:
-                module = self._fetch_extension_module(extension_name)
-                if module:
-                    self._remove_module_files_from_sandcat(module)
-
     async def _compile_new_agent(self, platform, headers, compile_target_name, output_name, buildmode='',
-                                 extldflags='', cflags='', flag_params=('server', 'group', 'listenP2P', 'c2'), extension_names=None):
+                                 extldflags='', cflags='', flag_params=default_flag_params, extension_names=None):
         """Compile sandcat agent using specified parameters. Will also include any requested extension modules."""
 
         plugin, file_path = await self.file_svc.find_file_path(compile_target_name)
@@ -126,57 +113,26 @@ class SandService(BaseService):
                                        cflags=cflags, build_dir=build_path)
 
         # Remove extension files.
-        if installed_extensions:
-            self.log.debug('Cleaning up files for gocat extension modules %s' % ', '.join(installed_extensions))
-            await self._uninstall_gocat_extensions(extension_names)
+        await self._uninstall_gocat_extensions(installed_extensions)
 
-    def _copy_module_files_to_sandcat(self, module):
-        """Given an extension module object, will copy the module-required files from the gocat-extension subdirectory
-        into the gocat subdirectory in order to compile the extension module into sandcat."""
+    async def _install_gocat_extensions(self, extension_names):
+        """Given a list of extension names, will copy the required files for each extension from the gocat-extensions
+        subdirectory into the gocat subdirectory."""
+        if which('go') is not None and extension_names:
+            self.log.debug('Installing gocat extension modules: %s' % ', '.join(extension_names))
+            return [name for name in extension_names if await self._attempt_module_copy(name=name)]
+        return []
 
-        if module:
-            try:
-                for file, pkg in module.files:
-                    try:
-                        # Make sure the package folders are there or are created.
-                        package_path = os.path.join(self.sandcat_dir, 'gocat', pkg)
-                        if not os.path.exists(package_path):
-                            os.makedirs(package_path)
+    async def _uninstall_gocat_extensions(self, extension_names):
+        """Given a list of extension names, will remove the required files for each extension from the gocat
+        subdirectory."""
 
-                        copyfile(src=os.path.join(self.sandcat_dir, 'gocat-extensions', pkg, file),
-                                 dst=os.path.join(self.sandcat_dir, 'gocat', pkg, file))
-                    except Exception as e:
-                        self.log.error('Error copying file %s, %s' % (file, e))
-            except Exception as e:
-                print(e)
+        if which('go') is not None and extension_names:
+            self.log.debug('Cleaning up files for gocat extension modules %s' % ', '.join(extension_names))
+            for extension_name in extension_names:
+                self.sandcat_extensions[extension_name].remove_module_files(base_dir=self.sandcat_dir)
 
-    def _remove_module_files_from_sandcat(self, module):
-        """Given an extension module object, will delete the module-required files from the gocat subdirectory
-        in order to provide a clean file structure for the next sandcat compilation."""
-
-        if module:
-            for file, pkg in module.files:
-                try:
-                    file_path = os.path.join(self.sandcat_dir, 'gocat', pkg, file)
-                    if os.path.exists(file_path):
-                        os.remove(file_path)
-                except Exception as e:
-                    self.log.error('Error copying file %s, %s' % (file, e))
-
-    def _fetch_extension_module(self, extension_name):
-        """Given an extension name, returns the extension module object for the extension, or None if not found."""
-
-        extension = None
-        for root, dirs, files in os.walk(os.path.join(self.sandcat_dir, 'app', 'extensions')):
-            files = [f for f in files if not f[0] == '.' and not f[0] == "_"]
-            dirs[:] = [d for d in dirs if not d[0] == '.' and not d[0] == "_"]
-            for file in files:
-                if file.lower() == extension_name.lower() + ".py":
-                    extension = self._load_extension_module(root, file)
-                    break
-        return extension
-
-    def _load_extension_module(self, root, file):
+    async def _load_extension_module(self, root, file):
         """Give the file path and file name for the extension module file, will return the extension
         module object. Helper method for _fetch_extension_module."""
 
@@ -186,3 +142,17 @@ class SandService(BaseService):
             return getattr(import_module(module), 'load')()
         except Exception as e:
             self.log.error('Error loading extension=%s, %s' % (module, e))
+
+    async def _attempt_module_copy(self, name):
+        """Attempts to copy the module files. Returns True upon success, False otherwise."""
+
+        module = self.sandcat_extensions.get(name)
+        if module:
+            try:
+                module.copy_module_files(base_dir=self.sandcat_dir)
+                return True
+            except Exception as e:
+                self.log.error('Copy failed: %s' % e)
+        else:
+            self.log.error('Module %s not found' % name)
+        return False

--- a/app/utility/base_extension.py
+++ b/app/utility/base_extension.py
@@ -13,7 +13,6 @@ class Extension(ABC):
         self.files = files
         self.dependencies = []
 
-
     def check_go_dependencies(self):
         for d in self.dependencies:
             dep_result = subprocess.run('go list "{}"'.format(d), shell=True, stdout=subprocess.PIPE)

--- a/app/utility/base_extension.py
+++ b/app/utility/base_extension.py
@@ -9,11 +9,16 @@ class Extension(ABC):
 
     @abstractmethod
     def __init__(self, files):
-        """files is list of 2-tuples of the form (filename, package)"""
+        """
+        Files is list of 2-tuples of the form (filename, package)
+        """
         self.files = files
         self.dependencies = []
 
     def check_go_dependencies(self):
+        """
+        Returns True if the golang dependencies are met for this module, False if not.
+        """
         for d in self.dependencies:
             dep_result = subprocess.run('go list "{}"'.format(d), shell=True, stdout=subprocess.PIPE)
             if (dep_result.stdout.decode()).strip() != d:
@@ -21,9 +26,10 @@ class Extension(ABC):
         return True
 
     def copy_module_files(self, base_dir):
-        """Copies module files into their corresponding location within the gocat directory.
-        Returns True on success, will throw an error on failure."""
-
+        """
+        Copies module files into their corresponding location within the gocat directory.
+        Returns True on success, will throw an error on failure.
+        """
         for file, pkg in self.files:
             # Make sure the package folders are there or are created.
             src_package_path = os.path.join(base_dir, 'gocat-extensions', pkg)
@@ -40,6 +46,9 @@ class Extension(ABC):
         return True
 
     def remove_module_files(self, base_dir):
+        """
+        Cleans up module-specific files from the gocat directory.
+        """
         for file, pkg in self.files:
             package_path = os.path.join(base_dir, 'gocat', pkg)
             # Check if entire package is to be deleted
@@ -51,14 +60,16 @@ class Extension(ABC):
                     os.remove(file_path)
 
     def install_dependencies(self):
-        """Attempt to install all dependencies if they aren't fulfilled. Returns True on success, False otherwise."""
-
+        """
+        Attempt to install all dependencies if they aren't fulfilled. Returns True on success, False otherwise.
+        """
         return False
 
     @staticmethod
     def _copy_folder_files(src_dir, dest_dir):
-        """Copies files from src_dir to dest_dir. Not recursive. Assumes src_dir and dest_dir are absolute paths."""
-
+        """
+        Copies files from src_dir to dest_dir. Not recursive. Assumes src_dir and dest_dir are absolute paths.
+        """
         for dir_item in os.listdir(src_dir):
             src_path = os.path.join(src_dir, dir_item)
             if os.path.isfile(src_path):
@@ -67,8 +78,9 @@ class Extension(ABC):
 
     @staticmethod
     def _unstage_folder(dir_path):
-        """Deletes files (except for load.go) from the directory at dir_path. Not recursive."""
-
+        """
+        Deletes files (except for load.go) from the directory at dir_path. Not recursive.
+        """
         for dir_item in os.listdir(dir_path):
             full_path = os.path.join(dir_path, dir_item)
             if os.path.isfile(full_path) and dir_item != 'load.go':

--- a/app/utility/base_extension.py
+++ b/app/utility/base_extension.py
@@ -1,5 +1,8 @@
+import os
 import subprocess
+
 from abc import ABC, abstractmethod
+from shutil import copyfile
 
 
 class Extension(ABC):
@@ -16,3 +19,40 @@ class Extension(ABC):
             if (dep_result.stdout.decode()).strip() != d:
                 return False
         return True
+
+    def copy_module_files(self, base_dir):
+        for file, pkg in self.files:
+            # Make sure the package folders are there or are created.
+            src_package_path = os.path.join(base_dir, 'gocat-extensions', pkg)
+            dest_package_path = os.path.join(base_dir, 'gocat', pkg)
+            if not os.path.exists(dest_package_path):
+                os.makedirs(dest_package_path)
+
+            # Check if entire package is to be copied
+            if file == '*':
+                for dir_item in os.listdir(src_package_path):
+                    src_path = os.path.join(src_package_path, dir_item)
+                    if os.path.isfile(src_path):
+                        copyfile(src=src_path,
+                                 dst=os.path.join(dest_package_path, dir_item))
+            else:
+                copyfile(src=os.path.join(src_package_path, file),
+                         dst=os.path.join(dest_package_path, file))
+
+    def remove_module_files(self, base_dir):
+        for file, pkg in self.files:
+            package_path = os.path.join(base_dir, 'gocat', pkg)
+            # Check if entire package is to be deleted
+            if file == '*':
+                for dir_item in os.listdir(package_path):
+                    full_path = os.path.join(package_path, dir_item)
+                    if os.path.isfile(full_path) and dir_item != 'load.go':
+                        os.remove(full_path)
+            else:
+                file_path = os.path.join(package_path, file)
+                if os.path.exists(file_path):
+                    os.remove(file_path)
+
+    def install_dependencies(self):
+        # Attempt to install all dependencies if they aren't fulfilled
+        pass

--- a/app/utility/base_extension.py
+++ b/app/utility/base_extension.py
@@ -13,6 +13,7 @@ class Extension(ABC):
         self.files = files
         self.dependencies = []
 
+
     def check_go_dependencies(self):
         for d in self.dependencies:
             dep_result = subprocess.run('go list "{}"'.format(d), shell=True, stdout=subprocess.PIPE)
@@ -21,6 +22,9 @@ class Extension(ABC):
         return True
 
     def copy_module_files(self, base_dir):
+        """Copies module files into their corresponding location within the gocat directory.
+        Returns True on success, will throw an error on failure."""
+
         for file, pkg in self.files:
             # Make sure the package folders are there or are created.
             src_package_path = os.path.join(base_dir, 'gocat-extensions', pkg)
@@ -30,29 +34,43 @@ class Extension(ABC):
 
             # Check if entire package is to be copied
             if file == '*':
-                for dir_item in os.listdir(src_package_path):
-                    src_path = os.path.join(src_package_path, dir_item)
-                    if os.path.isfile(src_path):
-                        copyfile(src=src_path,
-                                 dst=os.path.join(dest_package_path, dir_item))
+                self._copy_folder_files(src_package_path, dest_package_path)
             else:
                 copyfile(src=os.path.join(src_package_path, file),
                          dst=os.path.join(dest_package_path, file))
+        return True
 
     def remove_module_files(self, base_dir):
         for file, pkg in self.files:
             package_path = os.path.join(base_dir, 'gocat', pkg)
             # Check if entire package is to be deleted
             if file == '*':
-                for dir_item in os.listdir(package_path):
-                    full_path = os.path.join(package_path, dir_item)
-                    if os.path.isfile(full_path) and dir_item != 'load.go':
-                        os.remove(full_path)
+                self._unstage_folder(package_path)
             else:
                 file_path = os.path.join(package_path, file)
                 if os.path.exists(file_path):
                     os.remove(file_path)
 
     def install_dependencies(self):
-        # Attempt to install all dependencies if they aren't fulfilled
-        pass
+        """Attempt to install all dependencies if they aren't fulfilled. Returns True on success, False otherwise."""
+
+        return False
+
+    @staticmethod
+    def _copy_folder_files(src_dir, dest_dir):
+        """Copies files from src_dir to dest_dir. Not recursive. Assumes src_dir and dest_dir are absolute paths."""
+
+        for dir_item in os.listdir(src_dir):
+            src_path = os.path.join(src_dir, dir_item)
+            if os.path.isfile(src_path):
+                copyfile(src=src_path,
+                         dst=os.path.join(dest_dir, dir_item))
+
+    @staticmethod
+    def _unstage_folder(dir_path):
+        """Deletes files (except for load.go) from the directory at dir_path. Not recursive."""
+
+        for dir_item in os.listdir(dir_path):
+            full_path = os.path.join(dir_path, dir_item)
+            if os.path.isfile(full_path) and dir_item != 'load.go':
+                os.remove(full_path)

--- a/hook.py
+++ b/hook.py
@@ -15,3 +15,4 @@ async def enable(services):
     cat_gui_api = SandGuiApi(services=services)
     app.router.add_static('/sandcat', 'plugins/sandcat/static', append_version=True)
     app.router.add_route('GET', '/plugin/sandcat/gui', cat_gui_api.splash)
+    await sand_svc.load_sandcat_extension_modules()


### PR DESCRIPTION
Modules can also be installed as entire packages and not just single files (see `app/extensions/execute/shellcode/shellcode.py`)