### PR TITLE
Have server include proxy peers upon compilation

### DIFF
--- a/app/sand_svc.py
+++ b/app/sand_svc.py
@@ -113,8 +113,6 @@ class SandService(BaseService):
                 elif param == 'includePeers' and headers.get(param, "").lower() == "true":
                     encoded_info, xor_key = await self._get_encoded_proxy_peer_info()
                     if encoded_info and xor_key:
-                        print(encoded_info)
-                        print(xor_key) # debugging
                         ldflags.append('-X github.com/mitre/gocat/proxy.%s=%s' % ('encodedReceivers', encoded_info))
                         ldflags.append('-X github.com/mitre/gocat/proxy.%s=%s' % ('receiverKey', xor_key))
                 else:
@@ -144,7 +142,7 @@ class SandService(BaseService):
                         receiver_dict[protocol] = set()
                     for address in addressList:
                         receiver_dict[protocol].add(address)
-        for protocol, addressList in receiver_dict:
+        for protocol in receiver_dict:
             receiver_dict[protocol] = list(receiver_dict[protocol])
         return json.dumps(receiver_dict)
 
@@ -152,7 +150,6 @@ class SandService(BaseService):
         """XORs JSON-dumped available proxy receiver information with the given key string
         and returns the base64-encoded output along with the XOR key string."""
         receiver_info_json = await self._get_available_proxy_peer_info()
-        print(receiver_info_json) # debugging
         key = self._generate_key()
         if receiver_info_json:
             result = []

--- a/app/sand_svc.py
+++ b/app/sand_svc.py
@@ -154,7 +154,7 @@ class SandService(BaseService):
             for index in range(0, len(receiver_info_json)):
                 result.append(ord(receiver_info_json[index]) ^ ord(key[index % key_length]))
             return base64.b64encode(bytes(result)).decode('ascii'), key
-        return '',''
+        return '', ''
 
     async def _install_gocat_extensions(self, extension_names):
         """

--- a/app/sand_svc.py
+++ b/app/sand_svc.py
@@ -138,7 +138,7 @@ class SandService(BaseService):
         deduped_receivers = defaultdict(list)
         for agent in await self.data_svc.locate('agents', match=dict(trusted=True)):
             for protocol, addressList in agent.proxy_receivers.items():
-                deduped_receivers[protocol] += [address for address in addressList]
+                deduped_receivers[protocol] += addressList
         for protocol in deduped_receivers:
             deduped_receivers[protocol] = list(set(deduped_receivers[protocol]))
         return json.dumps(deduped_receivers)

--- a/app/sand_svc.py
+++ b/app/sand_svc.py
@@ -4,12 +4,13 @@ import os
 import pathlib
 import random
 import string
+from collections import defaultdict
 from importlib import import_module
 from shutil import which
 
 from app.utility.base_service import BaseService
 
-default_flag_params = ('server', 'group', 'listenP2P', 'c2', 'includePeers')
+default_flag_params = ('server', 'group', 'listenP2P', 'c2', 'includeProxyPeers')
 gocat_variants = dict(
     basic=set(),
     red=set(['gist', 'shared', 'shells', 'shellcode'])
@@ -110,7 +111,7 @@ class SandService(BaseService):
             if param in headers:
                 if param == 'c2':
                     ldflags.append('-X main.%s=%s' % (await self._get_c2_config(headers[param])))
-                elif param == 'includePeers' and headers.get(param, "").lower() == "true":
+                elif param == 'includeProxyPeers' and headers.get(param, False):
                     encoded_info, xor_key = await self._get_encoded_proxy_peer_info()
                     if encoded_info and xor_key:
                         ldflags.append('-X github.com/mitre/gocat/proxy.%s=%s' % ('encodedReceivers', encoded_info))
@@ -132,32 +133,28 @@ class SandService(BaseService):
         await self._uninstall_gocat_extensions(installed_extensions)
 
     async def _get_available_proxy_peer_info(self):
-        """Returns JSON-marshalled dict that maps proxy protocol (string) to a de-duped list of receiver addresses (string) for
-        trusted agents who are running proxy receivers."""
-        receiver_dict = dict()
-        for agent in await self.data_svc.locate('agents'):
-            if agent.trusted:
-                for protocol, addressList in agent.proxy_receivers.items():
-                    if protocol not in receiver_dict:
-                        receiver_dict[protocol] = set()
-                    for address in addressList:
-                        receiver_dict[protocol].add(address)
-        for protocol in receiver_dict:
-            receiver_dict[protocol] = list(receiver_dict[protocol])
-        return json.dumps(receiver_dict)
+        """Returns JSON-marshalled dict that maps proxy protocol (string) to a de-duped list of receiver addresses
+        (string) for trusted agents who are running proxy receivers."""
+        deduped_receivers = defaultdict(list)
+        for agent in await self.data_svc.locate('agents', match=dict(trusted=True)):
+            for protocol, addressList in agent.proxy_receivers.items():
+                deduped_receivers[protocol] += [address for address in addressList]
+        for protocol in deduped_receivers:
+            deduped_receivers[protocol] = list(set(deduped_receivers[protocol]))
+        return json.dumps(deduped_receivers)
 
     async def _get_encoded_proxy_peer_info(self):
         """XORs JSON-dumped available proxy receiver information with the given key string
         and returns the base64-encoded output along with the XOR key string."""
         receiver_info_json = await self._get_available_proxy_peer_info()
-        key = self._generate_key()
         if receiver_info_json:
             result = []
+            key = self._generate_key()
             key_length = len(key)
             for index in range(0, len(receiver_info_json)):
                 result.append(ord(receiver_info_json[index]) ^ ord(key[index % key_length]))
             return base64.b64encode(bytes(result)).decode('ascii'), key
-        return "", ""
+        return '',''
 
     async def _install_gocat_extensions(self, extension_names):
         """


### PR DESCRIPTION
By including the HTTP header "includeProxyPeers" and setting it to "True", the server will do the following:
- Get the proxy receiver addresses for trusted agents. Will be in a dict form, where the proxy protocol is the key and the address list is the value.
- JSON marshal the dict
- Generate a random key to XOR the json string
- base64 the XORed string and compile the base64 string and random key into the sandcat binary