### PR TITLE
Extension check

### DIFF
--- a/app/sand_svc.py
+++ b/app/sand_svc.py
@@ -81,7 +81,9 @@ class SandService(BaseService):
             for file in files:
                 module = await self._load_extension_module(root, file)
                 if module and (module.check_go_dependencies() or module.install_dependencies()):
-                    self.sandcat_extensions[file.split('.')[0]] = module
+                    module_name = file.split('.')[0]
+                    self.sandcat_extensions[module_name] = module
+                    self.log.debug('Loaded gocat extension module: %s' % module_name)
 
     """ PRIVATE """
 

--- a/app/sand_svc.py
+++ b/app/sand_svc.py
@@ -83,8 +83,7 @@ class SandService(BaseService):
                 if module:
                     if module.check_go_dependencies() or module.install_dependencies():
                         self.sandcat_extensions[file.split('.')[0]] = module
-                    else:
-                        self.log.error('Failed to fulfill dependencies for module %s' % module)
+                        self.log.debug('Loaded gocat extension module %s' % module)
 
     """ PRIVATE """
 

--- a/app/sand_svc.py
+++ b/app/sand_svc.py
@@ -80,10 +80,8 @@ class SandService(BaseService):
             dirs[:] = [d for d in dirs if not d[0] == '.' and not d[0] == "_"]
             for file in files:
                 module = await self._load_extension_module(root, file)
-                if module:
-                    if module.check_go_dependencies() or module.install_dependencies():
-                        self.sandcat_extensions[file.split('.')[0]] = module
-                        self.log.debug('Loaded gocat extension module %s' % module)
+                if module and (module.check_go_dependencies() or module.install_dependencies()):
+                    self.sandcat_extensions[file.split('.')[0]] = module
 
     """ PRIVATE """
 

--- a/app/utility/base_extension.py
+++ b/app/utility/base_extension.py
@@ -20,7 +20,8 @@ class Extension(ABC):
         Returns True if the golang dependencies are met for this module, False if not.
         """
         for d in self.dependencies:
-            dep_result = subprocess.run('go list "{}"'.format(d), shell=True, stdout=subprocess.PIPE)
+            dep_result = subprocess.run('go list "{}"'.format(d), shell=True,
+                                        stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
             if (dep_result.stdout.decode()).strip() != d:
                 return False
         return True


### PR DESCRIPTION
No longer outputs error messages when loading sandcat plugin and gocat extension dependencies are not met. Instead, the debug log will output all the successfully loaded gocat extensions.