### PR TITLE
Shared go update

### DIFF
--- a/app/sand_svc.py
+++ b/app/sand_svc.py
@@ -37,6 +37,7 @@ class SandService(BaseService):
             await self._compile_new_agent(platform=platform,
                                           headers=headers,
                                           compile_target_name=name,
+                                          cflags='CGO_ENABLED=0',
                                           output_name=name,
                                           extension_names=extension_names,
                                           compile_target_dir='gocat')
@@ -71,7 +72,7 @@ class SandService(BaseService):
                                               flag_params=default_flag_params,
                                               extension_names=extension_names,
                                               compile_target_dir='gocat/shared')
-        return '%s-%s' % (name, platform), self.generate_name()
+        return await self.app_svc.retrieve_compiled_file(name, platform)
 
     async def load_sandcat_extension_modules(self):
         """

--- a/app/sand_svc.py
+++ b/app/sand_svc.py
@@ -107,7 +107,6 @@ class SandService(BaseService):
         If a gocat variant is specified along with additional extensions, the extensions will be added to the
         base extensions for the variant.
         """
-        plugin, file_path = await self.file_svc.find_file_path(compile_target_name, location=compile_target_dir)
         ldflags = ['-s', '-w', '-X main.key=%s' % (self._generate_key(),)]
         for param in flag_params:
             if param in headers:
@@ -125,8 +124,9 @@ class SandService(BaseService):
 
         output = str(pathlib.Path('plugins/sandcat/payloads').resolve() / ('%s-%s' % (output_name, platform)))
 
-        # Load extensions and compile.
+        # Load extensions and compile. Extensions need to be loaded before searching for target file.
         installed_extensions = await self._install_gocat_extensions(extension_names)
+        plugin, file_path = await self.file_svc.find_file_path(compile_target_name, location=compile_target_dir)
         self.file_svc.log.debug('Dynamically compiling %s' % compile_target_name)
         build_path, build_file = os.path.split(file_path)
         await self.file_svc.compile_go(platform, output, build_file, buildmode=buildmode, ldflags=' '.join(ldflags),


### PR DESCRIPTION
Adding await statement
Making sure shared.go gets compiled correctly and that cgo flag is not used on non-library compilation 