### PR TITLE
File upload capabilities for GIST C2, SmbPipe C2 and proxy receiver, and HTTP proxy receiver

### DIFF
--- a/gocat-extensions/execute/donut/donut.go
+++ b/gocat-extensions/execute/donut/donut.go
@@ -146,6 +146,10 @@ func (d *Donut) SendExecutionResults(profile map[string]interface{}, result map[
 	d.contact.SendExecutionResults(profile, result)
 }
 
+func (d *Donut) UploadFileBytes(profile map[string]interface{}, uploadName string, data []byte) error {
+	return d.contact.UploadFileBytes(profile, uploadName, data)
+}
+
 func (d *Donut) GetName() string {
 	return d.contactName
 }

--- a/gocat-extensions/proxy/proxy_smb_pipe_util.go
+++ b/gocat-extensions/proxy/proxy_smb_pipe_util.go
@@ -39,6 +39,19 @@ type payloadResponseInfo struct {
 	PayloadData []byte
 }
 
+// Auxiliary struct that defines P2P message payload structure for an ability upload request
+type uploadRequestInfo struct {
+	UploadName string
+	UploadData []byte
+	Profile map[string]interface{}
+}
+
+// Auxiliary struct that defines P2P message payload structure for an ability upload response
+type uploadResponseInfo struct {
+	UploadName string
+	Result bool
+}
+
 /*
  * SMB Read/Write helper functions
  */


### PR DESCRIPTION
Agents can upload files via GIST C2 channel and SmbPipe C2 channel.
HTTP proxy receiver and SmbPipe proxy receiver will also forward file uploads for client agents.
Also updated donut to comply with the new gocat contact interface