### PR TITLE
WIP: PoC native execution

### DIFF
--- a/app/extensions/execute/native/native.py
+++ b/app/extensions/execute/native/native.py
@@ -1,0 +1,15 @@
+from plugins.sandcat.app.utility.base_extension import Extension
+
+
+def load():
+    return Native()
+
+
+class Native(Extension):
+
+    def __init__(self):
+        super().__init__([
+            ('native.go', 'execute/native'),
+            ('ip_addr.go', 'execute/native')
+        ])
+        self.dependencies = []

--- a/gocat-extensions/execute/native/ip_addr.go
+++ b/gocat-extensions/execute/native/ip_addr.go
@@ -2,30 +2,30 @@
 package native
 
 import (
-    "net"
+	"net"
 
 	"github.com/mitre/gocat/execute"
 )
 
 func getIPAddresses(chOutput chan []byte, chStatus chan string) {
-    output := []byte{}
-    status := "0"
+	output := []byte{}
+	status := "0"
 
-    addrs, err := net.InterfaceAddrs()
-    if err != nil {
-        output = []byte("Error fetching IP addresses")
-        status = execute.ERROR_STATUS
-    } else {
-        for _, a := range addrs {
-            if ipnet, ok := a.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
-                if ipnet.IP.To4() != nil {
-                    ip_address := []byte(ipnet.IP.String() + "\n")
-                    output = append(output, ip_address...)
-                }
-            }
-        }
-    }
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		output = []byte("Error fetching IP addresses")
+		status = execute.ERROR_STATUS
+	} else {
+		for _, a := range addrs {
+			if ipnet, ok := a.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
+				if ipnet.IP.To4() != nil {
+					ip_address := []byte(ipnet.IP.String() + "\n")
+					output = append(output, ip_address...)
+				}
+			}
+		}
+	}
 
-    chOutput <- output
-    chStatus <- status
+	chOutput <- output
+	chStatus <- status
 }

--- a/gocat-extensions/execute/native/ip_addr.go
+++ b/gocat-extensions/execute/native/ip_addr.go
@@ -1,0 +1,31 @@
+
+package native
+
+import (
+    "net"
+
+	"github.com/mitre/gocat/execute"
+)
+
+func getIPAddresses(chOutput chan []byte, chStatus chan string) {
+    output := []byte{}
+    status := "0"
+
+    addrs, err := net.InterfaceAddrs()
+    if err != nil {
+        output = []byte("Error fetching IP addresses")
+        status = execute.ERROR_STATUS
+    } else {
+        for _, a := range addrs {
+            if ipnet, ok := a.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
+                if ipnet.IP.To4() != nil {
+                    ip_address := []byte(ipnet.IP.String() + "\n")
+                    output = append(output, ip_address...)
+                }
+            }
+        }
+    }
+
+    chOutput <- output
+    chStatus <- status
+}

--- a/gocat-extensions/execute/native/native.go
+++ b/gocat-extensions/execute/native/native.go
@@ -3,11 +3,11 @@
 package native
 
 import (
-    "strings"
-    "time"
-    "os"
-    "strconv"
-    "fmt"
+	"strings"
+	"time"
+	"os"
+	"strconv"
+	"fmt"
 
 	"github.com/mitre/gocat/execute"
 )
@@ -34,30 +34,30 @@ func (n *Native) String() string {
 }
 
 func (n *Native) CheckIfAvailable() bool {
-    return true
+	return true
 }
 
 func (n *Native) runNativeExecutor(command string, timeout int) ([]byte, string, string) {
-    pid := strconv.Itoa(os.Getpid())
-    var cmd func(chan []byte, chan string)
-    chOutput := make(chan []byte)
-    chStatus := make(chan string)
+	pid := strconv.Itoa(os.Getpid())
+	var cmd func(chan []byte, chan string)
+	chOutput := make(chan []byte)
+	chStatus := make(chan string)
 
-    switch {
-    case strings.EqualFold(command, "ip_addr"):
-        cmd = getIPAddresses
-    default:
-        errorOutput := []byte("Invalid command: " + command)
-        return errorOutput, execute.ERROR_STATUS, pid
-    }
+	switch {
+	case strings.EqualFold(command, "ip_addr"):
+		cmd = getIPAddresses
+	default:
+		errorOutput := []byte("Invalid command: " + command)
+		return errorOutput, execute.ERROR_STATUS, pid
+	}
 
-    go cmd(chOutput, chStatus)
+	go cmd(chOutput, chStatus)
 
-    select {
-    case cmdOutput := <-chOutput:
-        status := <-chStatus
-    	return cmdOutput, status, pid
-    case <-time.After(time.Duration(timeout) * time.Second):
-    	return []byte("Timeout reached running: " + command), execute.TIMEOUT_STATUS, pid
-    }
+	select {
+	case cmdOutput := <-chOutput:
+		status := <-chStatus
+		return cmdOutput, status, pid
+	case <-time.After(time.Duration(timeout) * time.Second):
+		return []byte("Timeout reached running: " + command), execute.TIMEOUT_STATUS, pid
+	}
 }

--- a/gocat-extensions/execute/native/native.go
+++ b/gocat-extensions/execute/native/native.go
@@ -1,0 +1,63 @@
+// +build windows darwin linux
+
+package native
+
+import (
+    "strings"
+    "time"
+    "os"
+    "strconv"
+    "fmt"
+
+	"github.com/mitre/gocat/execute"
+)
+
+type Native struct {
+	shortName string
+	path string
+}
+
+func init() {
+	shell := &Native {
+		shortName: "native",
+	}
+	execute.Executors[shell.shortName] = shell
+	fmt.Println("LOADED NATIVE")
+}
+
+func (n *Native) Run(command string, timeout int, info execute.InstructionInfo) ([]byte, string, string) {
+	return n.runNativeExecutor(command, timeout)
+}
+
+func (n *Native) String() string {
+	return n.shortName
+}
+
+func (n *Native) CheckIfAvailable() bool {
+    return true
+}
+
+func (n *Native) runNativeExecutor(command string, timeout int) ([]byte, string, string) {
+    pid := strconv.Itoa(os.Getpid())
+    var cmd func(chan []byte, chan string)
+    chOutput := make(chan []byte)
+    chStatus := make(chan string)
+
+    switch {
+    case strings.EqualFold(command, "ip_addr"):
+        cmd = getIPAddresses
+    default:
+        errorOutput := []byte("Invalid command: " + command)
+        return errorOutput, execute.ERROR_STATUS, pid
+    }
+
+    go cmd(chOutput, chStatus)
+
+    select {
+    case cmdOutput := <-chOutput:
+        status := <-chStatus
+    	return cmdOutput, status, pid
+    case <-time.After(time.Duration(timeout) * time.Second):
+    	return []byte("Timeout reached running: " + command), execute.TIMEOUT_STATUS, pid
+    }
+}


### PR DESCRIPTION
Adding native execution in Sandcat. Run `ip_addr` to get newline-separated IP addresses.

Sample ability:

```
cat << 'EOF' > plugins/stockpile/data/abilities/collection/b9657106-c732-4adf-a048-c89fa5b86963.yml
---

- id: b9657106-c732-4adf-a048-c89fa5b86963
  name: Get IP Addresses (Native)
  description: Get IP addresses through golang agent
  tactic: collection
  technique:
    attack_id: T1016
    name: System Network Configuration Discovery
  platforms:
    windows:
      native:
        command: ip_addr
EOF
```