### PR TITLE
Virts 1709: Adding a Python Executor for Sandcat

### DIFF
--- a/app/extensions/execute/shells/shells.py
+++ b/app/extensions/execute/shells/shells.py
@@ -9,8 +9,8 @@ class Shells(Extension):
 
     def __init__(self):
         super().__init__([
-            ('cmd.go', 'execute/shells'),
             ('osascript.go', 'execute/shells'),
             ('powershell_core.go', 'execute/shells'),
+            ('python.go', 'execute/shells'),
         ])
         self.dependencies = []

--- a/gocat-extensions/execute/shells/python.go
+++ b/gocat-extensions/execute/shells/python.go
@@ -1,0 +1,67 @@
+// +build windows darwin linux
+
+package shells
+
+import (
+	"os/exec"
+//	"runtime"
+//	"fmt"
+
+	"github.com/mitre/gocat/execute"
+)
+
+type Python struct {
+	shortName string
+	path string
+	execArgs []string
+}
+
+func init() {
+//	var path string
+
+/*	var err string
+
+	if runtime.GOOS == "windows" {
+		path, err := exec.Command("powershell","where.exe","python.exe").Output()
+		if path == "INFO: Could not find files for the given pattern(s)." {
+		  //fmt.Println("Python is not installed\n")
+//		} else if path {
+            //path contains Python3*
+		} else {
+		    //fmt.Println("%s\n",path)
+		}
+// may not need
+	} else if runtime.GOOS == "linux" {
+	    //which python3
+	    path, err := exec.LookPath("python3").Output()
+	    if path == ""  {
+	        //fmt.Println("Python3 is not installed\n")
+		} else {
+		    //fmt.Println("%s\n",path)
+		}
+	} else {
+		path = "python3"
+	}
+*/
+
+	shell := &Python{
+		shortName: "python3",
+		path: "python3",
+		execArgs: []string{"-c"},
+	}
+	if shell.CheckIfAvailable() {
+		execute.Executors[shell.shortName] = shell
+	}
+}
+
+func (p *Python) Run(command string, timeout int, info execute.InstructionInfo) ([]byte, string, string) {
+	return runShellExecutor(*exec.Command(p.path, append(p.execArgs, command)...), timeout)
+}
+
+func (p *Python) String() string {
+	return p.shortName
+}
+
+func (p *Python) CheckIfAvailable() bool {
+	return checkExecutorInPath(p.path)
+} 

--- a/gocat-extensions/execute/shells/python.go
+++ b/gocat-extensions/execute/shells/python.go
@@ -4,9 +4,9 @@ package shells
 
 import (
 	"os/exec"
-//	"runtime"
-//	"fmt"
-
+	"runtime"
+	"fmt"
+	"github.com/mitre/gocat/output"
 	"github.com/mitre/gocat/execute"
 )
 
@@ -17,42 +17,35 @@ type Python struct {
 }
 
 func init() {
-//	var path string
+	if !(setPath("python3")) {
+		setPath("python")
+	}
+}
 
-/*	var err string
+func setPath(name string) bool {
+// Checks if python3 or python is available on the system and
+//sets the shell executor with the appropriate path
+	var path string
 
 	if runtime.GOOS == "windows" {
-		path, err := exec.Command("powershell","where.exe","python.exe").Output()
-		if path == "INFO: Could not find files for the given pattern(s)." {
-		  //fmt.Println("Python is not installed\n")
-//		} else if path {
-            //path contains Python3*
-		} else {
-		    //fmt.Println("%s\n",path)
-		}
-// may not need
-	} else if runtime.GOOS == "linux" {
-	    //which python3
-	    path, err := exec.LookPath("python3").Output()
-	    if path == ""  {
-	        //fmt.Println("Python3 is not installed\n")
-		} else {
-		    //fmt.Println("%s\n",path)
-		}
+		path = name + ".exe"
 	} else {
-		path = "python3"
+		path = name
 	}
-*/
 
-	shell := &Python{
+	shell := &Python {
 		shortName: "python3",
-		path: "python3",
+		path: path,
 		execArgs: []string{"-c"},
 	}
 	if shell.CheckIfAvailable() {
 		execute.Executors[shell.shortName] = shell
-	}
+		return true
+	} 
+	output.VerbosePrint(fmt.Sprintf("%s is not installed", name))
+	return false
 }
+
 
 func (p *Python) Run(command string, timeout int, info execute.InstructionInfo) ([]byte, string, string) {
 	return runShellExecutor(*exec.Command(p.path, append(p.execArgs, command)...), timeout)


### PR DESCRIPTION
## Description

Adding a python executor for sandcat

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [?] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
This works on Windows (10) and *nix (ubuntu 18 & macos) with python3 (executed via python[.exe] or python3[.exe])

## Checklist:

- [?] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] have added tests that prove my fix is effective or that my feature works
