### PR TITLE
Remove cmd reference from shells gocat extension

### DIFF
--- a/app/extensions/execute/shells/shells.py
+++ b/app/extensions/execute/shells/shells.py
@@ -9,7 +9,6 @@ class Shells(Extension):
 
     def __init__(self):
         super().__init__([
-            ('cmd.go', 'execute/shells'),
             ('osascript.go', 'execute/shells'),
             ('powershell_core.go', 'execute/shells'),
         ])


### PR DESCRIPTION
## Description
The cmd executor is already included in the default gocat agent. Its reference needs to be removed from the "shells" gocat extension - otherwise, the sandcat service will try to copy a non-existing cmd.go file from gocat-extensions/execute/shells to gocat/execute/shells and will generate an error.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Compiled gocat agent executable with the shells gocat-extension and verified that no error was generated. Also compiled stock gocat executable without any extensions. Verified that both agents had the cmd executor available.


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
