### PR TITLE
Moved getLocalIPv4Addresses() to agent_util.go in mitre/gocat to prev…

### DIFF
--- a/gocat-extensions/proxy/proxy_receiver_http.go
+++ b/gocat-extensions/proxy/proxy_receiver_http.go
@@ -308,7 +308,7 @@ func sendResponseToClient(data []byte, headers map[string][]string, writer http.
 // Port must be set for the HTTP receiver before calling this method.
 func (h *HttpReceiver) getReachableUrls() ([]string, error) {
 	var urlList []string
-	ipAddrs, err := getLocalIPv4Addresses()
+	ipAddrs, err := GetLocalIPv4Addresses()
 	if err != nil {
 		return nil, err
 	}

--- a/gocat-extensions/proxy/proxy_receiver_http.go
+++ b/gocat-extensions/proxy/proxy_receiver_http.go
@@ -308,7 +308,7 @@ func sendResponseToClient(data []byte, headers map[string][]string, writer http.
 // Port must be set for the HTTP receiver before calling this method.
 func (h *HttpReceiver) getReachableUrls() ([]string, error) {
 	var urlList []string
-	ipAddrs, err := h.getLocalIPv4Addresses()
+	ipAddrs, err := getLocalIPv4Addresses()
 	if err != nil {
 		return nil, err
 	}
@@ -317,34 +317,6 @@ func (h *HttpReceiver) getReachableUrls() ([]string, error) {
 		urlList = append(urlList, url)
 	}
 	return urlList, nil
-}
-
-// Return list of local IPv4 addresses for this machine (exclude loopback and unspecified addresses)
-func (h *HttpReceiver) getLocalIPv4Addresses() ([]string, error) {
-	var localIpList []string
-	interfaces, err := net.Interfaces()
-	if err != nil {
-		return nil, err
-	}
-	for _, iface := range interfaces {
-		addresses, err := iface.Addrs()
-		if err != nil {
-			return nil, err
-		}
-		for _, addr := range addresses {
-			var ipAddr net.IP
-			switch v:= addr.(type) {
-			case *net.IPNet:
-				ipAddr = v.IP
-			case *net.IPAddr:
-				ipAddr = v.IP
-			}
-			if ipAddr != nil && !ipAddr.IsLoopback() && !ipAddr.IsUnspecified() && (ipAddr.To4() != nil) {
-				localIpList = append(localIpList, ipAddr.String())
-			}
-		}
-	}
-	return localIpList, nil
 }
 
 // Helper method for initializing the receiver port.


### PR DESCRIPTION
…ent code duplication, since this function is needed by agent.go as well. Call to this function in the edited file has been updated accordingly.

## Description
Adding local IP address fetching function to sandcat. This is one 1/4 pull requests, in addition to:

https://github.com/mitre/gocat/pull/48
https://github.com/mitre/caldera/pull/2056
A yet-to-be-created fieldmanual PR.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Agent IP address functionality is working on my local system. Proxy functionality has not yet been tested to unsure it hasn't been broken.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
