### PR TITLE
Proxy implementation update for stored server/contact

### DIFF
--- a/gocat-extensions/proxy/proxy_smb_pipe_util.go
+++ b/gocat-extensions/proxy/proxy_smb_pipe_util.go
@@ -56,8 +56,8 @@ type uploadResponseInfo struct {
  * SMB Read/Write helper functions
  */
 
-// Send a P2pMessage to the server using the specified server pipe path, paw, message type, payload, and return mailbox path.
-func sendRequestToServer(pipePath string, paw string, messageType int, payload []byte, returnMailBoxPipePath string) error {
+// Send a P2pMessage to the specified server pipe path with specified paw, message type, payload, and return mailbox path.
+func sendRequestToUpstreamPipe(pipePath string, paw string, messageType int, payload []byte, returnMailBoxPipePath string) error {
     pipeMsgData, err := buildP2pMsgBytes(paw, messageType, payload, returnMailBoxPipePath)
     if err != nil {
     	return err


### PR DESCRIPTION
## Description
Update existing proxy implementations to conform with changes in https://github.com/mitre/gocat/pull/49

- SmbPipe client will keep track of agent's upstream dest address
- Proxy implementations now store a pointer to the agent's server value, removing the need to explicitly call methods to update it if the agent changes its server.
- Proxy implementations now store a pointer to the agent's current contact mechanism, removing the need to explicitly call methods to update it if the agent switches contact channels.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Tested running agents with HTTP and SmbPipe proxy to make sure contacts worked properly.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
