### PR TITLE
GIST contact comply with new contact interface method

### DIFF
--- a/gocat-extensions/contact/gist.go
+++ b/gocat-extensions/contact/gist.go
@@ -83,7 +83,7 @@ func (g GIST) C2RequirementsMet(profile map[string]interface{}, criteria map[str
     return false, nil
 }
 
-func (g GIST) SetUpstreamDestAddr(upstreamDestAddr *string) {
+func (g GIST) SetUpstreamDestAddr(upstreamDestAddr string) {
 	// Upstream destination will be the github API.
 	return
 }

--- a/gocat-extensions/contact/gist.go
+++ b/gocat-extensions/contact/gist.go
@@ -83,6 +83,11 @@ func (g GIST) C2RequirementsMet(profile map[string]interface{}, criteria map[str
     return false, nil
 }
 
+func (g GIST) SetUpstreamDestAddr(upstreamDestAddr *string) {
+	// Upstream destination will be the github API.
+	return
+}
+
 //SendExecutionResults send results to the server
 func (g GIST) SendExecutionResults(profile map[string]interface{}, result map[string]interface{}){
 	profileCopy := make(map[string]interface{})


### PR DESCRIPTION
## Description
Update GIST contact to have it conform with new contact interface by implementing the new contact method SetUpstreamDestAddr, as defined in https://github.com/mitre/gocat/pull/49

Since GIST will always reach out to github, SetUpstreamDestAddr will simply return without doing anything. However, since the GIST contact implements the contact interface, the method still needs to exist.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Tested GIST contact with https://github.com/mitre/gocat/pull/49 to make sure it still works properly.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
