### PR TITLE
VIRTS-1709: Adding python executor to sandcat

### DIFF
--- a/app/extensions/execute/shells/shells.py
+++ b/app/extensions/execute/shells/shells.py
@@ -11,5 +11,6 @@ class Shells(Extension):
         super().__init__([
             ('osascript.go', 'execute/shells'),
             ('powershell_core.go', 'execute/shells'),
+            ('python.go', 'execute/shells')
         ])
         self.dependencies = []

--- a/gocat-extensions/execute/shells/python.go
+++ b/gocat-extensions/execute/shells/python.go
@@ -1,0 +1,87 @@
+// +build windows darwin linux
+
+package shells
+
+import (
+	"os/exec"
+	"runtime"
+	"fmt"
+	"strings"
+	"github.com/mitre/gocat/output"
+	"github.com/mitre/gocat/execute"
+)
+
+type Python struct {
+	shortName string
+	path string
+	execArgs []string
+}
+
+func init() {
+	setExecutor("python3")
+	setExecutor("python")
+}
+
+func setExecutor(name string) bool {
+// Checks if python3 or python is available on the system and
+// sets the shell executor with the appropriate path
+	var path string
+	var val string
+	var sName string
+	
+	if runtime.GOOS == "windows" {
+		path = name + ".exe"
+	} else {
+		path = name
+	}
+
+	if name == "python" {
+		val = checkVersion(name)
+		sName = "python" + val
+	} else {
+		sName = name
+	}
+
+	shell := &Python {
+		shortName: sName,
+		path: path,
+		execArgs: []string{"-c"},
+	}
+	if shell.CheckIfAvailable() {
+		execute.Executors[shell.shortName] = shell
+		return true
+	} 
+	fmt.Print("%s is not installed", name)
+	return false
+}
+
+func checkVersion(name string) string {
+	var str_ver string
+// checks the python version 
+	version, err := exec.Command("python", "-c", "import platform; print(platform.python_version().split('.')[0])").CombinedOutput()
+	fmt.Print("version", string(version), "\n")
+	if err != nil {
+		fmt.Print("Error:", err, "\n")
+	}
+// returns the first number from the python version (i.e. python version 2.7.1 would return 2 as a string)
+	str_ver = string(version)
+	str_ver = strings.TrimSuffix(str_ver, "\n")
+	str_ver = strings.TrimSuffix(str_ver, "\r")
+	return str_ver
+}
+
+func (p *Python) Run(command string, timeout int, info execute.InstructionInfo) ([]byte, string, string) {
+	return runShellExecutor(*exec.Command(p.path, append(p.execArgs, command)...), timeout)
+}
+
+func (p *Python) String() string {
+	return p.shortName
+}
+
+func (p *Python) CheckIfAvailable() bool {
+	return checkExecutorInPath(p.path)
+} 
+
+func (p *Python) DownloadPayloadToMemory(payloadName string) bool {
+	return false
+}

--- a/gocat-extensions/execute/shells/python.go
+++ b/gocat-extensions/execute/shells/python.go
@@ -7,7 +7,7 @@ import (
 	"runtime"
 	"fmt"
 	"strings"
-	"github.com/mitre/gocat/output"
+//	"github.com/mitre/gocat/output"
 	"github.com/mitre/gocat/execute"
 )
 
@@ -65,8 +65,8 @@ func checkVersion(name string) string {
 	}
 // returns the first number from the python version (i.e. python version 2.7.1 would return 2 as a string)
 	str_ver = string(version)
-	str_ver = strings.TrimSuffix(str_ver, "\n")
-	str_ver = strings.TrimSuffix(str_ver, "\r")
+	str_ver = strings.TrimSpace(str_ver, "\n\r")
+//	str_ver = strings.TrimSpace(string(version), "\n\r")
 	return str_ver
 }
 

--- a/gocat-extensions/execute/shells/python.go
+++ b/gocat-extensions/execute/shells/python.go
@@ -63,6 +63,7 @@ func checkVersion(name string) string {
 	fmt.Print("version", string(version), "\n")
 	if err != nil {
 		fmt.Print("Error:", err, "\n")
+		return ""
 	}
 	str_ver = strings.TrimSpace(string(version))
 	return str_ver

--- a/gocat-extensions/execute/shells/python.go
+++ b/gocat-extensions/execute/shells/python.go
@@ -7,7 +7,6 @@ import (
 	"runtime"
 	"fmt"
 	"strings"
-//	"github.com/mitre/gocat/output"
 	"github.com/mitre/gocat/execute"
 )
 

--- a/gocat-extensions/execute/shells/python.go
+++ b/gocat-extensions/execute/shells/python.go
@@ -19,11 +19,12 @@ type Python struct {
 
 func init() {
 	setExecutor("python3")
+	setExecutor("python2")
 	setExecutor("python")
 }
 
 func setExecutor(name string) bool {
-// Checks if python3 or python is available on the system and
+// Checks if python3, python2, or python is available on the system and
 // sets the shell executor with the appropriate path
 	var path string
 	var val string
@@ -51,22 +52,19 @@ func setExecutor(name string) bool {
 		execute.Executors[shell.shortName] = shell
 		return true
 	} 
-	fmt.Print("%s is not installed", name)
+	fmt.Print(name, " is not installed\n")
 	return false
 }
 
+// checks the python version and returns the major version
 func checkVersion(name string) string {
 	var str_ver string
-// checks the python version 
 	version, err := exec.Command("python", "-c", "import platform; print(platform.python_version().split('.')[0])").CombinedOutput()
 	fmt.Print("version", string(version), "\n")
 	if err != nil {
 		fmt.Print("Error:", err, "\n")
 	}
-// returns the first number from the python version (i.e. python version 2.7.1 would return 2 as a string)
-	str_ver = string(version)
-	str_ver = strings.TrimSpace(str_ver, "\n\r")
-//	str_ver = strings.TrimSpace(string(version), "\n\r")
+	str_ver = strings.TrimSpace(string(version))
 	return str_ver
 }
 


### PR DESCRIPTION
## Description

Adding python executors for sandcat and checks the version of python on the system and returns the appropriate executor name (supports python3 and python2).

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

This works on Windows (10) and *nix (ubuntu 18 & macos) with python3 (executed via python[.exe] or python3[.exe]) and python2. If a system has both versions, two python executors are made. 

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
