### PR TITLE
Adding optional hooks when copying extension files

### DIFF
--- a/app/sand_svc.py
+++ b/app/sand_svc.py
@@ -223,7 +223,7 @@ class SandService(BaseService):
         module = self.sandcat_extensions.get(name)
         if module:
             try:
-                return module.copy_module_files(base_dir=self.sandcat_dir)
+                return await module.copy_module_files(base_dir=self.sandcat_dir)
             except Exception as e:
                 self.log.error('Error copying files for module %s: %s' % (module, e))
         else:

--- a/app/utility/base_extension.py
+++ b/app/utility/base_extension.py
@@ -2,23 +2,20 @@ import os
 import subprocess
 
 from abc import ABC, abstractmethod
-from shutil import copyfile
 
 
 class Extension(ABC):
 
     @abstractmethod
-    def __init__(self, files):
-        """
-        Files is list of 2-tuples of the form (filename, package)
-        """
+    def __init__(self, files, dependencies=None, file_hooks=None):
+        """Files is list of 2-tuples of the form (filename, package)"""
         self.files = files
-        self.dependencies = []
+        self.dependencies = dependencies if dependencies else []
+        # Maps file name to async function that takes in file data, processes it, and returns processed output.
+        self.file_hooks = file_hooks if file_hooks else dict()
 
     def check_go_dependencies(self):
-        """
-        Returns True if the golang dependencies are met for this module, False if not.
-        """
+        """Returns True if the golang dependencies are met for this module, False if not."""
         for d in self.dependencies:
             dep_result = subprocess.run('go list "{}"'.format(d), shell=True,
                                         stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
@@ -26,11 +23,11 @@ class Extension(ABC):
                 return False
         return True
 
-    def copy_module_files(self, base_dir):
-        """
-        Copies module files into their corresponding location within the gocat directory.
-        Returns True on success, will throw an error on failure.
-        """
+    async def copy_module_files(self, base_dir):
+        """Copies module files into their corresponding location within the gocat directory.
+        If a hook function is assigned to the file, run the hook function on the file data before
+        copying it to the gocat directory.
+        Returns True on success."""
         for file, pkg in self.files:
             # Make sure the package folders are there or are created.
             src_package_path = os.path.join(base_dir, 'gocat-extensions', pkg)
@@ -40,16 +37,14 @@ class Extension(ABC):
 
             # Check if entire package is to be copied
             if file == '*':
-                self._copy_folder_files(src_package_path, dest_package_path)
+                await self._copy_folder_files(src_package_path, dest_package_path)
             else:
-                copyfile(src=os.path.join(src_package_path, file),
-                         dst=os.path.join(dest_package_path, file))
+                await self._copy_file_with_hook(file, os.path.join(src_package_path, file),
+                                                os.path.join(dest_package_path, file))
         return True
 
     def remove_module_files(self, base_dir):
-        """
-        Cleans up module-specific files from the gocat directory.
-        """
+        """Cleans up module-specific files from the gocat directory."""
         for file, pkg in self.files:
             package_path = os.path.join(base_dir, 'gocat', pkg)
             # Check if entire package is to be deleted
@@ -61,27 +56,27 @@ class Extension(ABC):
                     os.remove(file_path)
 
     def install_dependencies(self):
-        """
-        Attempt to install all dependencies if they aren't fulfilled. Returns True on success, False otherwise.
-        """
+        """Attempt to install all dependencies if they aren't fulfilled. Returns True on success, False otherwise."""
         return False
 
-    @staticmethod
-    def _copy_folder_files(src_dir, dest_dir):
-        """
-        Copies files from src_dir to dest_dir. Not recursive. Assumes src_dir and dest_dir are absolute paths.
-        """
+    async def _copy_folder_files(self, src_dir, dest_dir):
+        """Copies files from src_dir to dest_dir. Not recursive. Assumes src_dir and dest_dir are absolute paths."""
         for dir_item in os.listdir(src_dir):
             src_path = os.path.join(src_dir, dir_item)
             if os.path.isfile(src_path):
-                copyfile(src=src_path,
-                         dst=os.path.join(dest_dir, dir_item))
+                await self._copy_file_with_hook(dir_item, src_path, os.path.join(dest_dir, dir_item))
+
+    async def _copy_file_with_hook(self, file_name, src_path, dest_path):
+        with open(src_path, 'r') as src_file:
+            data = src_file.read()
+        if file_name in self.file_hooks:
+            data = await self.file_hooks[file_name](data)
+        with open(dest_path, 'w') as dest_file:
+            dest_file.write(data)
 
     @staticmethod
     def _unstage_folder(dir_path):
-        """
-        Deletes files (except for load.go) from the directory at dir_path. Not recursive.
-        """
+        """Deletes files (except for load.go) from the directory at dir_path. Not recursive."""
         for dir_item in os.listdir(dir_path):
             full_path = os.path.join(dir_path, dir_item)
             if os.path.isfile(full_path) and dir_item != 'load.go':


### PR DESCRIPTION
## Description
Adding framework to include hook functions that get executed when copying gocat extension files for compilation. This allows users to invoke python functions to edit golang files at compile time, such as using caldera configuration file settings to change variables within golang code.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?
Tested compilation using a custom hook function for a sandcat extension and verified that the changes were reflected in the resulting golang executable.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
