### PR TITLE
Dns extension file hook

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 180

--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,0 @@
-[flake8]
-max-line-length = 180

--- a/app/extensions/contact/dns_tunneling.py
+++ b/app/extensions/contact/dns_tunneling.py
@@ -9,6 +9,7 @@ FILE_NAME = 'dns_tunneling.go'
 DOMAIN_CONFIG = 'app.contact.dns.domain'
 TEXT_TO_REPLACE = r'{DNS_TUNNELING_C2_DOMAIN}'
 
+
 def load():
     return DnsTunneling()
 

--- a/app/extensions/contact/dns_tunneling.py
+++ b/app/extensions/contact/dns_tunneling.py
@@ -7,9 +7,7 @@ GOCAT_PLUGIN = 'gocat'
 PACKAGE_NAME = 'contact'
 FILE_NAME = 'dns_tunneling.go'
 DOMAIN_CONFIG = 'app.contact.dns.domain'
-TEXT_TO_REPLACE = r'BASE_DOMAIN = "mycaldera.caldera"'
-REPLACEMENT_TEMPLATE = 'BASE_DOMAIN = "{}"'
-
+TEXT_TO_REPLACE = r'{DNS_TUNNELING_C2_DOMAIN}'
 
 def load():
     return DnsTunneling()
@@ -25,8 +23,6 @@ class DnsTunneling(Extension):
         """Will replace the C2 domain variable with the domain in the C2 configuration."""
         domain_name = BaseWorld.get_config(prop=DOMAIN_CONFIG)
         if domain_name:
-            replacement_text = REPLACEMENT_TEMPLATE.format(domain_name)
-            new_data = re.sub(TEXT_TO_REPLACE, replacement_text, original_data, count=1)
-            return new_data
+            return re.sub(TEXT_TO_REPLACE, domain_name, original_data, count=1)
         else:
             raise Exception('No DNS tunneling domain specified in C2 configuration file under app.contact.dns.domain')

--- a/app/extensions/contact/dns_tunneling.py
+++ b/app/extensions/contact/dns_tunneling.py
@@ -1,4 +1,14 @@
+import re
+
+from app.utility.base_world import BaseWorld
 from plugins.sandcat.app.utility.base_extension import Extension
+
+GOCAT_PLUGIN = 'gocat'
+PACKAGE_NAME = 'contact'
+FILE_NAME = 'dns_tunneling.go'
+DOMAIN_CONFIG = 'app.contact.dns.domain'
+TEXT_TO_REPLACE = r'BASE_DOMAIN = "mycaldera.caldera"'
+REPLACEMENT_TEMPLATE = 'BASE_DOMAIN = "{}"'
 
 
 def load():
@@ -6,7 +16,17 @@ def load():
 
 
 class DnsTunneling(Extension):
-
     def __init__(self):
-        super().__init__([('dns_tunneling.go', 'contact')])
-        self.dependencies = ['github.com/miekg/dns']
+        super().__init__([(FILE_NAME, PACKAGE_NAME)],
+                         dependencies=['github.com/miekg/dns'],
+                         file_hooks={FILE_NAME: self.hook_set_custom_domain})
+
+    async def hook_set_custom_domain(self, original_data):
+        """Will replace the C2 domain variable with the domain in the C2 configuration."""
+        domain_name = BaseWorld.get_config(prop=DOMAIN_CONFIG)
+        if domain_name:
+            replacement_text = REPLACEMENT_TEMPLATE.format(domain_name)
+            new_data = re.sub(TEXT_TO_REPLACE, replacement_text, original_data, count=1)
+            return new_data
+        else:
+            raise Exception('No DNS tunneling domain specified in C2 configuration file under app.contact.dns.domain')

--- a/app/sand_svc.py
+++ b/app/sand_svc.py
@@ -225,7 +225,7 @@ class SandService(BaseService):
             try:
                 return await module.copy_module_files(base_dir=self.sandcat_dir)
             except Exception as e:
-                self.log.error('Error copying files for module %s: %s' % (module, e))
+                self.log.error('Error copying files for module %s: %s', name, e)
         else:
             self.log.error('Module %s not found' % name)
         return False

--- a/gocat-extensions/contact/dns_tunneling.go
+++ b/gocat-extensions/contact/dns_tunneling.go
@@ -23,7 +23,7 @@ const (
 	RECORD_TYPE_A = 1
 	RECORD_TYPE_TXT = 16
 	TIMEOUT_SECONDS = 10
-	BASE_DOMAIN = "mycaldera.caldera"
+	BASE_DOMAIN = "{DNS_TUNNELING_C2_DOMAIN}"
 	MIN_MESSAGE_ID = 10000000
 	MAX_MESSAGE_ID = 99999999
 	MAX_UPLOAD_CHUNK_SIZE = 31 // DNS label is 63 characters max, so 31 bytes in hex reaches 62 characters.


### PR DESCRIPTION
## Description
Rather than having the domain hardcoded in the golang code for DNS tunneling, use the module installation file hook to dynamically find the C2 domain from the main config file and place it in the golang code during compilation.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?
Verified compiling and running a sandcat agent with the DNS tunneling gocat extension.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
