### PR TITLE
Return execution timestamp in gocat executor extensions

### DIFF
--- a/gocat-extensions/execute/donut/donut.go
+++ b/gocat-extensions/execute/donut/donut.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"runtime"
+	"time"
 
 	"github.com/mitre/gocat/execute"
 	"github.com/mitre/gocat/output"
@@ -26,7 +27,7 @@ func init() {
 
 const COMMANDLINE string = "rundll32.exe"
 
-func (d *Donut) Run(command string, timeout int, info execute.InstructionInfo) ([]byte, string, string) {
+func (d *Donut) Run(command string, timeout int, info execute.InstructionInfo) ([]byte, string, string, time.Time) {
     // Setup variables
     stdoutBytes := make([]byte, 1)
     stderrBytes := make([]byte, 1)
@@ -42,6 +43,7 @@ func (d *Donut) Run(command string, timeout int, info execute.InstructionInfo) (
 
         // Run the shellcode and wait for it to complete
         output.VerbosePrint(fmt.Sprint("[i] Donut: Running shellcode"))
+        executionTimestamp := time.Now()
         task, err := Runner(bytes, handle, stdout, &stdoutBytes, stderr, &stderrBytes, &eventCode)
         output.VerbosePrint(fmt.Sprint("[i] Donut: Shellcode execution finished"))
 
@@ -57,14 +59,14 @@ func (d *Donut) Run(command string, timeout int, info execute.InstructionInfo) (
             total += "STDERR:\n"
             total += string(stderrBytes)
 
-            return []byte(total), execute.SUCCESS_STATUS, fmt.Sprint(pid)
+            return []byte(total), execute.SUCCESS_STATUS, fmt.Sprint(pid), executionTimestamp
         }
 
         // Covers the cases where an error was received before the remote thread was created
-        return []byte(fmt.Sprintf("Shellcode execution failed. Error message: %s", fmt.Sprint(err))), execute.ERROR_STATUS, fmt.Sprint(pid)
+        return []byte(fmt.Sprintf("Shellcode execution failed. Error message: %s", fmt.Sprint(err))), execute.ERROR_STATUS, fmt.Sprint(pid), executionTimestamp
     } else {
         // Empty payload
-        return []byte(fmt.Sprintf("Empty payload: %s", payload)), execute.ERROR_STATUS, "-1"
+        return []byte(fmt.Sprintf("Empty payload: %s", payload)), execute.ERROR_STATUS, "-1", time.Now()
     }
 }
 

--- a/gocat-extensions/execute/shellcode/shellcode.go
+++ b/gocat-extensions/execute/shellcode/shellcode.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strings"
 	"unicode"
+	"time"
 
 	"github.com/mitre/gocat/execute"
 )
@@ -27,13 +28,14 @@ func init() {
 	}
 }
 
-func (s *Shellcode) Run(command string, timeout int, info execute.InstructionInfo) ([]byte, string, string) {
+func (s *Shellcode) Run(command string, timeout int, info execute.InstructionInfo) ([]byte, string, string, time.Time) {
 	bytes, _ := stringToByteArrayString(command)
+	executionTimestamp := time.Now()
 	task, pid := Runner(bytes)
 	if task {
-		return []byte("Shellcode executed successfully."), execute.SUCCESS_STATUS, pid
+		return []byte("Shellcode executed successfully."), execute.SUCCESS_STATUS, pid, executionTimestamp
 	}
-	return []byte("Shellcode execution failed."), execute.ERROR_STATUS, pid
+	return []byte("Shellcode execution failed."), execute.ERROR_STATUS, pid, executionTimestamp
 }
 
 func (s *Shellcode) String() string {

--- a/gocat-extensions/execute/shells/osascript.go
+++ b/gocat-extensions/execute/shells/osascript.go
@@ -4,6 +4,7 @@ package shells
 
 import (
 	"os/exec"
+	"time"
 
 	"github.com/mitre/gocat/execute"
 )
@@ -25,7 +26,7 @@ func init() {
 	}
 }
 
-func (o *Osascript) Run(command string, timeout int, info execute.InstructionInfo) ([]byte, string, string) {
+func (o *Osascript) Run(command string, timeout int, info execute.InstructionInfo) ([]byte, string, string, time.Time) {
 	return runShellExecutor(*exec.Command(o.path, append(o.execArgs, command)...), timeout)
 }
 

--- a/gocat-extensions/execute/shells/powershell_core.go
+++ b/gocat-extensions/execute/shells/powershell_core.go
@@ -5,6 +5,7 @@ package shells
 import (
 	"os/exec"
 	"runtime"
+	"time"
 
 	"github.com/mitre/gocat/execute"
 )
@@ -32,7 +33,7 @@ func init() {
 	}
 }
 
-func (p *PowershellCore) Run(command string, timeout int, info execute.InstructionInfo) ([]byte, string, string) {
+func (p *PowershellCore) Run(command string, timeout int, info execute.InstructionInfo) ([]byte, string, string, time.Time) {
 	return runShellExecutor(*exec.Command(p.path, append(p.execArgs, command)...), timeout)
 }
 

--- a/gocat-extensions/execute/shells/python.go
+++ b/gocat-extensions/execute/shells/python.go
@@ -7,6 +7,8 @@ import (
 	"runtime"
 	"fmt"
 	"strings"
+	"time"
+
 	"github.com/mitre/gocat/execute"
 )
 
@@ -68,7 +70,7 @@ func checkVersion(name string) string {
 	return str_ver
 }
 
-func (p *Python) Run(command string, timeout int, info execute.InstructionInfo) ([]byte, string, string) {
+func (p *Python) Run(command string, timeout int, info execute.InstructionInfo) ([]byte, string, string, time.Time) {
 	return runShellExecutor(*exec.Command(p.path, append(p.execArgs, command)...), timeout)
 }
 


### PR DESCRIPTION
## Description
Update gocat extensions for executors to return the execution timestamp. This will comply with the new executor interface.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Successfully compiled executor extensions, and tested an ability with the donut extension.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
