### PR TITLE
Allow executors to update their binary paths

### DIFF
--- a/gocat-extensions/execute/donut/donut.go
+++ b/gocat-extensions/execute/donut/donut.go
@@ -89,3 +89,7 @@ func getDonutBytes(inMemoryPayloads map[string][]byte) (string, []byte) {
 	}
 	return "", nil
 }
+
+func (d *Donut) UpdateBinary(newBinary string) {
+	return
+}

--- a/gocat-extensions/execute/shellcode/shellcode.go
+++ b/gocat-extensions/execute/shellcode/shellcode.go
@@ -50,6 +50,10 @@ func (s *Shellcode) DownloadPayloadToMemory(payloadName string) bool {
 	return false
 }
 
+func (s *Shellcode) UpdateBinary(newBinary string) {
+	return
+}
+
 func stringToByteArrayString(input string) ([]byte, error) {
 	temp := removeWhiteSpace(input)
 	temp = strings.Replace(temp, "0x", "", -1)

--- a/gocat-extensions/execute/shells/osascript.go
+++ b/gocat-extensions/execute/shells/osascript.go
@@ -41,3 +41,7 @@ func (o *Osascript) CheckIfAvailable() bool {
 func (o *Osascript) DownloadPayloadToMemory(payloadName string) bool {
 	return false
 }
+
+func (o *Osascript) UpdateBinary(newBinary string) {
+	o.path = newBinary
+}

--- a/gocat-extensions/execute/shells/powershell_core.go
+++ b/gocat-extensions/execute/shells/powershell_core.go
@@ -48,3 +48,7 @@ func (p *PowershellCore) CheckIfAvailable() bool {
 func (p *PowershellCore) DownloadPayloadToMemory(payloadName string) bool {
 	return false
 }
+
+func (p *PowershellCore) UpdateBinary(newBinary string) {
+	p.path = newBinary
+}

--- a/gocat-extensions/execute/shells/python.go
+++ b/gocat-extensions/execute/shells/python.go
@@ -85,3 +85,7 @@ func (p *Python) CheckIfAvailable() bool {
 func (p *Python) DownloadPayloadToMemory(payloadName string) bool {
 	return false
 }
+
+func (p *Python) UpdateBinary(newBinary string) {
+	p.path = newBinary
+}


### PR DESCRIPTION
## Description
Extension executors can update their binary paths using new executor interface method

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Tested compiling the executor extensions and tested updating executor paths.


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
