### PR TITLE
Moving gocat github badge and adding basic workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,37 @@
+name: Go
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+        ref: master
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16
+
+    - name: Mod tidy
+      run: |
+        cd gocat
+        go mod tidy
+
+    - name: Build
+      run: |
+        cd gocat
+        go build -v .
+
+    - name: Test binary
+      run: |
+        cd gocat
+        file gocat && ./gocat -help

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# 54ndc47
+# 54ndc47 (Sandcat)
+[![Go](https://github.com/mitre/sandcat/actions/workflows/go.yml/badge.svg)](https://github.com/mitre/sandcat/actions/workflows/go.yml)
 
 A plugin supplying a default agent to be used in a CALDERA operation.
 

--- a/gocat/README.md
+++ b/gocat/README.md
@@ -1,2 +1,0 @@
-# gocat
-[![Go](https://github.com/mitre/gocat/actions/workflows/go.yml/badge.svg)](https://github.com/mitre/gocat/actions/workflows/go.yml)


### PR DESCRIPTION
## Description
Moving gocat github badge to sandcat repo.
Adding basic workflow to compile gocat on branch pushes.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Allowed github workflow to complete successfully


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
