### PR TITLE
Gocat Extension UTC Time

### DIFF
--- a/gocat-extensions/execute/donut/donut.go
+++ b/gocat-extensions/execute/donut/donut.go
@@ -43,7 +43,7 @@ func (d *Donut) Run(command string, timeout int, info execute.InstructionInfo) (
 
         // Run the shellcode and wait for it to complete
         output.VerbosePrint(fmt.Sprint("[i] Donut: Running shellcode"))
-        executionTimestamp := time.Now()
+        executionTimestamp := time.Now().UTC()
         task, err := Runner(bytes, handle, stdout, &stdoutBytes, stderr, &stderrBytes, &eventCode)
         output.VerbosePrint(fmt.Sprint("[i] Donut: Shellcode execution finished"))
 

--- a/gocat-extensions/execute/donut/donut.go
+++ b/gocat-extensions/execute/donut/donut.go
@@ -66,7 +66,7 @@ func (d *Donut) Run(command string, timeout int, info execute.InstructionInfo) (
         return []byte(fmt.Sprintf("Shellcode execution failed. Error message: %s", fmt.Sprint(err))), execute.ERROR_STATUS, fmt.Sprint(pid), executionTimestamp
     } else {
         // Empty payload
-        return []byte(fmt.Sprintf("Empty payload: %s", payload)), execute.ERROR_STATUS, "-1", time.Now()
+        return []byte(fmt.Sprintf("Empty payload: %s", payload)), execute.ERROR_STATUS, "-1", time.Now().UTC()
     }
 }
 

--- a/gocat-extensions/execute/shellcode/shellcode.go
+++ b/gocat-extensions/execute/shellcode/shellcode.go
@@ -30,7 +30,7 @@ func init() {
 
 func (s *Shellcode) Run(command string, timeout int, info execute.InstructionInfo) ([]byte, string, string, time.Time) {
 	bytes, _ := stringToByteArrayString(command)
-	executionTimestamp := time.Now()
+	executionTimestamp := time.Now().UTC()
 	task, pid := Runner(bytes)
 	if task {
 		return []byte("Shellcode executed successfully."), execute.SUCCESS_STATUS, pid, executionTimestamp


### PR DESCRIPTION
## Description
Donut and shellcode executors will now report execution timestamps in UTC time

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Tested the executors and confirmed UTC timestamps


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
