### PR TITLE
Using full file path for agent executable loc for linux/darwin

### DIFF
--- a/gocat/agent/agent.go
+++ b/gocat/agent/agent.go
@@ -107,7 +107,7 @@ func (a *Agent) Initialize(server string, tunnelConfig *contact.TunnelConfig, gr
 	a.host = host
 	a.architecture = runtime.GOARCH
 	a.platform = runtime.GOOS
-	a.location = os.Args[0]
+	a.location = getExecutablePath()
 	a.pid = os.Getpid()
 	a.ppid = os.Getppid()
 	a.privilege = privdetect.Privlevel()

--- a/gocat/agent/agent_util.go
+++ b/gocat/agent/agent_util.go
@@ -1,10 +1,13 @@
 package agent
 
 import (
+	"fmt"
 	"os"
 	"os/user"
 	"os/exec"
 	"time"
+
+	"github.com/mitre/gocat/output"
 )
 
 // Checks for a file
@@ -50,4 +53,14 @@ func getUsername() (string, error) {
 
 func getFormattedTimestamp(timestamp time.Time, dateFormat string) (string) {
     return timestamp.Format(dateFormat)
+}
+
+func getExecutablePath() (string) {
+	path, err := os.Executable()
+	if err != nil {
+		output.VerbosePrint(fmt.Sprintf("Error obtaining executable path: %s", err.Error()))
+		output.VerbosePrint("Obtaining path from command-line argument instead.")
+		return os.Args[0]
+	}
+	return path
 }


### PR DESCRIPTION
## Description
Rather than having the agent executable location represented as a relative file path (e.g. `./binary`) for linux/darwin agents, the agent binary will be represented as an absolute file path (e.g. `/path/to/binary`).

This will allow the `#{location}` fact to be used more reliably for linux/darwin abilities, since we can't always guarantee that the running command will be in the same referenced location as the original binary.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Ran agents on all 3 operating systems and verified that the location is an absolute file path.


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
