### PR TITLE
VIRTS-3125: Make Python Executor Initialization Output Less Confusing

### DIFF
--- a/gocat-extensions/execute/shells/python.go
+++ b/gocat-extensions/execute/shells/python.go
@@ -19,13 +19,10 @@ type Python struct {
 }
 
 func init() {
-	var three bool = false
-	var two bool = false
-	var one bool = false
-	three = setExecutor("python3")
-	two = setExecutor("python2")
-	one = setExecutor("python")
-	if three == false && two == false && one == false {
+	python3Detected := setExecutor("python3")
+	python2Detected := setExecutor("python2")
+	pythonDetected := setExecutor("python")
+	if !(python3Detected || python2Detected || pythonDetected) {
 		// if no versions found
 		fmt.Print("No python versions detected\n")
 	}
@@ -70,7 +67,6 @@ func checkVersion(name string) string {
 	version, err := exec.Command("python", "-c", "import platform; print(platform.python_version().split('.')[0])").CombinedOutput()
 	str_ver = strings.TrimSpace(string(version))
 	if err != nil {
-		//fmt.Print("Error:", err, "\n")
 		return ""
 	}
 	return str_ver

--- a/gocat-extensions/execute/shells/python.go
+++ b/gocat-extensions/execute/shells/python.go
@@ -19,9 +19,16 @@ type Python struct {
 }
 
 func init() {
-	setExecutor("python3")
-	setExecutor("python2")
-	setExecutor("python")
+	var three bool = false
+	var two bool = false
+	var one bool = false
+	three = setExecutor("python3")
+	two = setExecutor("python2")
+	one = setExecutor("python")
+	if three == false && two == false && one == false {
+		// if no versions found
+		fmt.Print("No python versions detected\n")
+	}
 }
 
 func setExecutor(name string) bool {
@@ -51,9 +58,9 @@ func setExecutor(name string) bool {
 	}
 	if shell.CheckIfAvailable() {
 		execute.Executors[shell.shortName] = shell
+		fmt.Print(sName, " detected \n")
 		return true
 	} 
-	fmt.Print(name, " is not installed\n")
 	return false
 }
 
@@ -61,12 +68,11 @@ func setExecutor(name string) bool {
 func checkVersion(name string) string {
 	var str_ver string
 	version, err := exec.Command("python", "-c", "import platform; print(platform.python_version().split('.')[0])").CombinedOutput()
-	fmt.Print("version", string(version), "\n")
+	str_ver = strings.TrimSpace(string(version))
 	if err != nil {
-		fmt.Print("Error:", err, "\n")
+		//fmt.Print("Error:", err, "\n")
 		return ""
 	}
-	str_ver = strings.TrimSpace(string(version))
 	return str_ver
 }
 


### PR DESCRIPTION
## Description

Python Executor Initialization now just prints what versions are found and "No python versions found" if not. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I tested this on Ubuntu 20 and Windows 10 with python versions available and a Windows 10 without python. 

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
