### PR TITLE
Feature/command handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.tokens
 *__pycache__*
 .idea/*
+.vscode/*
 .logs/*
 !.logs/.gitkeep
 .idea

--- a/gocat/agent/agent.go
+++ b/gocat/agent/agent.go
@@ -22,6 +22,7 @@ import (
 	"github.com/mitre/gocat/output"
 	"github.com/mitre/gocat/privdetect"
 	"github.com/mitre/gocat/proxy"
+	"github.com/mitre/gocat/payload"
 )
 
 var beaconFailureThreshold = 3
@@ -284,8 +285,16 @@ func (a *Agent) runInstructionCommand(instruction map[string]interface{}) map[st
 	if !ok {
 		cmd_handler = handler.DefaultName
 	}
+
 	// Execute command
-	commandOutput, status, pid, commandTimestamp := handler.Handlers[cmd_handler].HandleCommand(info)
+	var commandOutput []byte
+	var status, pid string 
+	var commandTimestamp time.Time
+	if ch, ok := handler.Handlers[cmd_handler]; ok {
+		commandOutput, status, pid, commandTimestamp = ch.HandleCommand(info)
+	} else {
+		commandOutput, status, pid, commandTimestamp = handler.Handlers[handler.DefaultName].HandleCommand(info)
+	}
 
 	// Clean up payloads
 	a.removePayloadsOnDisk(onDiskPayloads)
@@ -443,7 +452,7 @@ func (a *Agent) DownloadPayloadsForInstruction(instruction map[string]interface{
 			output.VerbosePrint(fmt.Sprintf("[*] Storing payload %s in memory", payloadName))
 			inMemoryPayloads[payloadName] = payloadBytes
 		} else {
-			if location, err := a.WritePayloadToDisk(payloadName, payloadBytes); err != nil {
+			if location, err := payload.WriteToDisk(payloadName, payloadBytes); err != nil {
 				output.VerbosePrint(fmt.Sprintf("[-] %s", err.Error()))
 			} else {
 				onDiskPayloadNames = append(onDiskPayloadNames, location)
@@ -451,19 +460,6 @@ func (a *Agent) DownloadPayloadsForInstruction(instruction map[string]interface{
 		}
 	}
 	return onDiskPayloadNames, inMemoryPayloads
-}
-
-// Will download the specified payload data to disk using the specified filename.
-// Returns filepath of the payload and any errors that occurred. If the payload already exists,
-// no error will be returned.
-func (a *Agent) WritePayloadToDisk(filename string, payloadBytes []byte) (string, error) {
-	location := filepath.Join(filename)
-	if !fileExists(location) {
-		output.VerbosePrint(fmt.Sprintf("[*] Writing payload %s to disk at %s", filename, location))
-		return location, writePayloadBytes(location, payloadBytes)
-	}
-	output.VerbosePrint(fmt.Sprintf("[*] File %s already exists", filename))
-	return location, nil
 }
 
 // Will request payload bytes from the C2 for the specified payload and return them.

--- a/gocat/agent/agent_util.go
+++ b/gocat/agent/agent_util.go
@@ -1,26 +1,12 @@
 package agent
 
 import (
-	"fmt"
-	"os"
 	"os/exec"
 	"os/user"
 	"time"
 
 	"github.com/mitre/gocat/output"
 )
-
-// Checks for a file
-func fileExists(path string) bool {
-	_, err := os.Stat(path)
-	if err == nil {
-		return true
-	}
-	if os.IsNotExist(err) {
-		return false
-	}
-	return true
-}
 
 func getUsername() (string, error) {
 	if userInfo, err := user.Current(); err != nil {

--- a/gocat/agent/agent_util.go
+++ b/gocat/agent/agent_util.go
@@ -3,8 +3,8 @@ package agent
 import (
 	"fmt"
 	"os"
-	"os/user"
 	"os/exec"
+	"os/user"
 	"time"
 
 	"github.com/mitre/gocat/output"
@@ -22,23 +22,6 @@ func fileExists(path string) bool {
 	return true
 }
 
-// Creates payload from []bytes
-func writePayloadBytes(location string, payload []byte) error {
-	dst, err := os.Create(location)
-	if err != nil {
-		return err
-	} else {
-		defer dst.Close()
-		if _, err = dst.Write(payload); err != nil {
-			return err
-		} else if err = os.Chmod(location, 0700); err != nil {
-			return err
-		} else {
-			return nil
-		}
-	}
-}
-
 func getUsername() (string, error) {
 	if userInfo, err := user.Current(); err != nil {
 		if usernameBytes, err := exec.Command("whoami").CombinedOutput(); err == nil {
@@ -51,8 +34,8 @@ func getUsername() (string, error) {
 	}
 }
 
-func getFormattedTimestamp(timestamp time.Time, dateFormat string) (string) {
-    return timestamp.Format(dateFormat)
+func getFormattedTimestamp(timestamp time.Time, dateFormat string) string {
+	return timestamp.Format(dateFormat)
 }
 
 func getExecutablePath() (string) {

--- a/gocat/agent/agent_util.go
+++ b/gocat/agent/agent_util.go
@@ -1,8 +1,10 @@
 package agent
 
 import (
-	"os/exec"
+	"fmt"
+	"os"
 	"os/user"
+	"os/exec"
 	"time"
 
 	"github.com/mitre/gocat/output"

--- a/gocat/execute/execute.go
+++ b/gocat/execute/execute.go
@@ -1,21 +1,16 @@
 package execute
 
-import (
-	"encoding/base64"
-	"path/filepath"
-	"fmt"
-	"time"
-	"os"
-	"strings"
-)
+import "time"
 
 const (
-	SUCCESS_STATUS 	= "0"
-	ERROR_STATUS 	= "1"
-	TIMEOUT_STATUS 	= "124"
-	SUCCESS_PID 	= "0"
-	ERROR_PID       = "1"
+	SUCCESS_STATUS = "0"
+	ERROR_STATUS   = "1"
+	TIMEOUT_STATUS = "124"
+	SUCCESS_PID    = "0"
+	ERROR_PID      = "1"
 )
+
+var Executors = map[string]Executor{}
 
 type Executor interface {
 	// Run takes a command string, timeout int, and instruction info.
@@ -30,75 +25,20 @@ type Executor interface {
 }
 
 type InstructionInfo struct {
-	Profile map[string]interface{}
-	Instruction map[string]interface{}
-	OnDiskPayloads []string
+	Profile          map[string]interface{}
+	Instruction      map[string]interface{}
+	OnDiskPayloads   []string
 	InMemoryPayloads map[string][]byte
 }
 
 func AvailableExecutors() (values []string) {
-	for _, e := range Executors {
-		values = append(values, e.String())
+	names := make([]string, 0, len(Executors))
+	for key := range Executors {
+		names = append(names, key)
 	}
-	return
-}
-
-var Executors = map[string]Executor{}
-
-//RunCommand runs the actual command
-func RunCommand(info InstructionInfo) ([]byte, string, string, time.Time) {
-	encodedCommand := info.Instruction["command"].(string)
-	executor := info.Instruction["executor"].(string)
-	timeout := int(info.Instruction["timeout"].(float64))
-	onDiskPayloads := info.OnDiskPayloads
-	var status string
-	var result []byte
-	var pid string
-	var executionTimestamp time.Time
-	decoded, err := base64.StdEncoding.DecodeString(encodedCommand)
-	if err != nil {
-		result = []byte(fmt.Sprintf("Error when decoding command: %s", err.Error()))
-		status = ERROR_STATUS
-		pid = ERROR_STATUS
-		executionTimestamp = time.Now().UTC()
-	} else {
-		command := string(decoded)
-		missingPaths := checkPayloadsAvailable(onDiskPayloads)
-		if len(missingPaths) == 0 {
-			result, status, pid, executionTimestamp = Executors[executor].Run(command, timeout, info)
-		} else {
-			result = []byte(fmt.Sprintf("Payload(s) not available: %s", strings.Join(missingPaths, ", ")))
-			status = ERROR_STATUS
-			pid = ERROR_STATUS
-			executionTimestamp = time.Now().UTC()
-		}
-	}
-	return result, status, pid, executionTimestamp
+	return names
 }
 
 func RemoveExecutor(name string) {
 	delete(Executors, name)
-}
-
-//checkPayloadsAvailable determines if any payloads are not on disk
-func checkPayloadsAvailable(payloads []string) []string {
-	var missing []string
-	for i := range payloads {
-		if fileExists(filepath.Join(payloads[i])) == false {
-			missing = append(missing, payloads[i])
-		}
-	}
-	return missing
-}
-
-// checks for a file
-func fileExists(path string) bool {
-	_, err := os.Stat(path)
-	if err == nil {
-		return true
-	}
-	if os.IsNotExist(err) {
-		return false
-	}
-	return true
 }

--- a/gocat/execute/shells/proc.go
+++ b/gocat/execute/shells/proc.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
 	"github.com/google/shlex"
 
 	"github.com/mitre/gocat/execute"

--- a/gocat/handler/config_handler.go
+++ b/gocat/handler/config_handler.go
@@ -1,0 +1,92 @@
+package handler
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/mitre/gocat/execute"
+	"github.com/mitre/gocat/handler"
+	"github.com/mitre/gocat/payload"
+)
+
+const name = "dab-dsl"
+
+type ConfigCommandHandler struct {
+	handler.BaseCommandHandler
+	shortName string
+}
+
+func init() {
+	handler.Handlers[name] = &ConfigCommandHandler{
+		shortName: name,
+	}
+}
+
+//Run the actual command
+func (ch *ConfigCommandHandler) HandleCommand(info execute.InstructionInfo) ([]byte, string, string, time.Time) {
+	// This layer is above executor and below agent.
+	// 1) Parse instruction header for executor
+	// 2) Dump behavior DSL into a JSON on disk (IDEA: consider support for CLi JSON passing too, or IPC (after startup))
+	// 3) run the payload (parser + runner + action library) w/ the JSON
+	// 4) add JSON file to payloads in InstructionInfo so it can be removed if the payload doesn't.
+
+	var status string
+	var result []byte
+	var pid string
+
+	err_handler := func(str string) ([]byte, string, string, time.Time) {
+		result = []byte(str)
+		status = execute.ERROR_STATUS
+		pid = execute.ERROR_STATUS
+		return result, status, pid, time.Now()
+	}
+
+	encodedCommand := info.Instruction["command"].(string)
+	executor := info.Instruction["executor"].(string)
+	timeout := int(info.Instruction["timeout"].(float64))
+	onDiskPayloads := info.OnDiskPayloads
+
+	decoded, err := base64.StdEncoding.DecodeString(encodedCommand)
+	if err != nil {
+		return err_handler(fmt.Sprintf("Error when decoding command: %s", err.Error()))
+	}
+
+	command := make(map[string]interface{}) // TODO marshal this into a JSON schema struct for validation
+	err = json.Unmarshal([]byte(string(decoded)), &command)
+	if err != nil {
+		return err_handler(fmt.Sprintf("Error when unmarshaling command JSON: %s", err.Error()))
+	}
+
+	// Write behavior DSL to disk and add it to payloads.
+	_, err = WriteConfigToDisk(command["behavior"])
+	if err != nil {
+		return err_handler(fmt.Sprintf("Error when writing DSL to disk: %s", err.Error()))
+	}
+
+	missingPaths := payload.CheckIfOnDisk(onDiskPayloads)
+	if len(missingPaths) != 0 {
+		return err_handler(fmt.Sprintf("Payload(s) not available: %s", strings.Join(missingPaths, ", ")))
+	}
+
+	header := command["header"].(map[string]interface{})
+	run_cmd := header["start_command"].(string)
+
+	return execute.Executors[executor].Run(run_cmd, timeout, info)
+}
+
+func WriteConfigToDisk(data interface{}, filename_opt ...string) (string, error) {
+	// Save DSL to JSON file on disk
+	// FIXME: Need to figure out best way to name this
+	filename := "config"
+	if len(filename_opt) > 0 {
+		filename = filename_opt[0]
+	}
+	if file, err := json.MarshalIndent(data, "", " "); err != nil {
+		return "", err
+	} else {
+		return payload.WriteToDisk(filename, file)
+	}
+}

--- a/gocat/handler/handler.go
+++ b/gocat/handler/handler.go
@@ -1,0 +1,97 @@
+package handler
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/mitre/gocat/execute"
+	"github.com/mitre/gocat/payload"
+)
+
+const DefaultName = "base"
+
+var Handlers = map[string]CommandHandler{}
+
+type CommandHandler interface {
+	HandleCommand(info execute.InstructionInfo) ([]byte, string, string, time.Time)
+	AddPayloads(onDisk []string, inMemory map[string][]byte)
+	GetPayloads() ([]string, map[string][]byte)
+	String() string
+	//GetStatus() string
+}
+
+func init() {
+	Handlers[DefaultName] = &BaseCommandHandler{
+		shortName:    DefaultName,
+		diskPayloads: make(map[string]struct{}),
+		memPayloads:  make(map[string][]byte),
+	}
+}
+
+type BaseCommandHandler struct {
+	shortName    string
+	diskPayloads map[string]struct{}
+	memPayloads  map[string][]byte
+}
+
+//Run the actual command
+func (ch *BaseCommandHandler) HandleCommand(info execute.InstructionInfo) ([]byte, string, string, time.Time) {
+	encodedCommand := info.Instruction["command"].(string)
+	executor := info.Instruction["executor"].(string)
+	timeout := int(info.Instruction["timeout"].(float64))
+	onDiskPayloads := info.OnDiskPayloads
+	var status string
+	var result []byte
+	var pid string
+	var executionTimestamp time.Time
+	decoded, err := base64.StdEncoding.DecodeString(encodedCommand)
+	if err != nil {
+		result = []byte(fmt.Sprintf("Error when decoding command: %s", err.Error()))
+		status = execute.ERROR_STATUS
+		pid = execute.ERROR_STATUS
+		executionTimestamp = time.Now()
+	} else {
+		command := string(decoded)
+		missingPaths := payload.CheckIfOnDisk(onDiskPayloads)
+		if len(missingPaths) == 0 {
+			result, status, pid, executionTimestamp = execute.Executors[executor].Run(command, timeout, info)
+		} else {
+			result = []byte(fmt.Sprintf("Payload(s) not available: %s", strings.Join(missingPaths, ", ")))
+			status = execute.ERROR_STATUS
+			pid = execute.ERROR_STATUS
+			executionTimestamp = time.Now()
+		}
+	}
+	return result, status, pid, executionTimestamp
+}
+
+func (ch *BaseCommandHandler) String() string {
+	return ch.shortName
+}
+
+func (ch *BaseCommandHandler) AddPayloads(onDisk []string, inMemory map[string][]byte) {
+	for _, v := range onDisk {
+		ch.diskPayloads[v] = struct{}{}
+	}
+	for k, v := range inMemory {
+		ch.memPayloads[k] = v
+	}
+}
+
+func (ch *BaseCommandHandler) GetPayloads() ([]string, map[string][]byte) {
+	diskPayloadNames := make([]string, 0, len(ch.diskPayloads))
+	for key := range ch.diskPayloads {
+		diskPayloadNames = append(diskPayloadNames, key)
+	}
+	return diskPayloadNames, ch.memPayloads
+}
+
+func AvailableCommandHandlers() (values []string) {
+	names := make([]string, 0, len(Handlers))
+	for key := range Handlers {
+		names = append(names, key)
+	}
+	return names
+}

--- a/gocat/handler/handler.go
+++ b/gocat/handler/handler.go
@@ -71,12 +71,20 @@ func (ch *BaseCommandHandler) String() string {
 	return ch.shortName
 }
 
+func (ch *BaseCommandHandler) AddDiskPayload(name string) {
+	ch.diskPayloads[name] = struct{}{}
+}
+
+func (ch *BaseCommandHandler) AddMemoryPayload(name string, data []byte) {
+	ch.memPayloads[name] = data
+}
+
 func (ch *BaseCommandHandler) AddPayloads(onDisk []string, inMemory map[string][]byte) {
 	for _, v := range onDisk {
-		ch.diskPayloads[v] = struct{}{}
+		ch.AddDiskPayload(v)
 	}
 	for k, v := range inMemory {
-		ch.memPayloads[k] = v
+		ch.AddMemoryPayload(k, v)
 	}
 }
 

--- a/gocat/payload/disk.go
+++ b/gocat/payload/disk.go
@@ -1,0 +1,62 @@
+package payload
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/mitre/gocat/output"
+)
+
+// Will download the specified payload data to disk using the specified filename.
+// Returns filepath of the payload and any errors that occurred. If the payload already exists,
+// no error will be returned.
+func WriteToDisk(filename string, payloadBytes []byte) (string, error) {
+	location := filepath.Join(filename)
+	if !FileExists(location) {
+		output.VerbosePrint(fmt.Sprintf("[*] Writing payload %s to disk at %s", filename, location))
+		return location, WriteBytes(location, payloadBytes)
+	}
+	output.VerbosePrint(fmt.Sprintf("[*] File %s already exists", filename))
+	return location, nil
+}
+
+// Creates from []bytes
+func WriteBytes(location string, payload []byte) error {
+	dst, err := os.Create(location)
+	if err != nil {
+		return err
+	} else {
+		defer dst.Close()
+		if _, err = dst.Write(payload); err != nil {
+			return err
+		} else if err = os.Chmod(location, 0700); err != nil {
+			return err
+		} else {
+			return nil
+		}
+	}
+}
+
+//Determine if any payloads are not on disk
+func CheckIfOnDisk(payloads []string) []string {
+	var missing []string
+	for i := range payloads {
+		if !FileExists(filepath.Join(payloads[i])) {
+			missing = append(missing, payloads[i])
+		}
+	}
+	return missing
+}
+
+// Checks for a file
+func FileExists(path string) bool {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true
+	}
+	if os.IsNotExist(err) {
+		return false
+	}
+	return true
+}

--- a/gocat/sandcat.go
+++ b/gocat/sandcat.go
@@ -15,13 +15,13 @@ These default  values can be overridden during linking - server, group, and slee
 with command-line arguments at runtime.
 */
 var (
-	key       = "JWHQZM9Z4HQOYICDHW4OCJAXPPNHBA"
-	server    = "http://localhost:8888"
-	paw       = ""
-	group     = "red"
-	c2Name    = "HTTP"
-	c2Key     = ""
-	listenP2P = "false" // need to set as string to allow ldflags -X build-time variable change on server-side.
+	key              = "JWHQZM9Z4HQOYICDHW4OCJAXPPNHBA"
+	server           = "http://localhost:8888"
+	paw              = ""
+	group            = "red"
+	c2Name           = "HTTP"
+	c2Key            = ""
+	listenP2P        = "false" // need to set as string to allow ldflags -X build-time variable change on server-side.
 	httpProxyGateway = ""
 )
 
@@ -31,7 +31,7 @@ func main() {
 		parsedListenP2P = false
 	}
 	server := flag.String("server", server, "The FQDN of the server")
-	httpProxyUrl :=  flag.String("httpProxyGateway", httpProxyGateway, "URL for the HTTP proxy gateway. For environments that use proxies to reach the internet.")
+	httpProxyUrl := flag.String("httpProxyGateway", httpProxyGateway, "URL for the HTTP proxy gateway. For environments that use proxies to reach the internet.")
 	paw := flag.String("paw", paw, "Optionally specify a PAW on initialization")
 	group := flag.String("group", group, "Attach a group to this agent")
 	c2Protocol := flag.String("c2", c2Name, "C2 Channel for agent")
@@ -53,8 +53,8 @@ func main() {
 		return
 	}
 	contactConfig := map[string]string{
-		"c2Name": *c2Protocol,
-		"c2Key": c2Key,
+		"c2Name":           *c2Protocol,
+		"c2Key":            c2Key,
 		"httpProxyGateway": *httpProxyUrl,
 	}
 	core.Core(trimmedServer, tunnelConfig, *group, *delay, contactConfig, *listenP2P, *verbose, *paw, *originLinkID)


### PR DESCRIPTION
## Description

Adds a command handler layer before the executor layer. 
This layer allows for development of handlers which can interpret the command string in different ways, allowing for different interactions with executors or even non-executor commands (e.g., commands meant to interact with the agent in other ways). 

There is a `base_handler` which is the same as current behavior and will act as the default fallback. 

A `json_handler` has been added, which allows for the command to have a JSON blob which will be saved to a JSON file and passed to the payload as an argument. This essentially allows facts to be used in a JSON configuration file to be provided to the payload.

Other, non-breaking, changes have also been included in this PR. Such as adding a `payload` package for storing payload related utility functions (such as `payload/disk.go` for on-disk payload interaction). By removing these utility functions from the `agent` package, other layers (such as the handler) can leverage them without circular import issues. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - Requires merge of server branch `feature/agent_handler`: https://github.com/mitre/caldera/pull/2420

## How Has This Been Tested?

This has been tested with the matching server branch on both Linux and Windows, for both the server and the agent. An OSX test will be ran soon.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
