### PR TITLE
Adding basic system info capabilities

### DIFF
--- a/gocat-extensions/execute/native/discovery/system_info.go
+++ b/gocat-extensions/execute/native/discovery/system_info.go
@@ -1,0 +1,57 @@
+package discovery
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/mitre/gocat/execute/native/util"
+)
+
+func init() {
+	util.NativeMethods["SystemInfo"] = GetSystemInfo
+	util.NativeMethods["systeminfo"] = GetSystemInfo
+}
+
+type infoGetterFunc func() (string, error)
+
+// Returns information about the current system. Ignores any provided args
+func GetSystemInfo(args []string) util.NativeCmdResult {
+	return util.NativeCmdResult{
+		Stdout: []byte(getSystemInfo()),
+		Stderr: nil,
+		Err: nil,
+	}
+}
+
+func getHostnameLine(hostnameGetterFunc infoGetterFunc) string {
+	return getInfoLine("Host Name", hostnameGetterFunc)
+}
+
+func getHostname() (string, error) {
+	return os.Hostname()
+}
+
+func getOsNameLine(osNameGetterFunc infoGetterFunc) string {
+	return getInfoLine("OS Name", osNameGetterFunc)
+}
+
+func getOsVersionLine(osVersionGetterFunc infoGetterFunc) string {
+	return getInfoLine("OS Version", osVersionGetterFunc)
+}
+
+func getHardwareTypeLine(hardwareTypeGetterFunc infoGetterFunc) string {
+	return getInfoLine("Hardware Type", hardwareTypeGetterFunc)
+}
+
+func getInfoLine(keyName string, getterFunc infoGetterFunc) string {
+	infoValue, err := getterFunc()
+	if err != nil {
+		return formatInfoLine("ERROR GETTING " + strings.ToUpper(keyName), err.Error())
+	}
+	return formatInfoLine(keyName, infoValue)
+}
+
+func formatInfoLine(key, value string) string {
+	return fmt.Sprintf("%-*s %s", keyWidth, key + ": ", value)
+}

--- a/gocat-extensions/execute/native/discovery/system_info_nix.go
+++ b/gocat-extensions/execute/native/discovery/system_info_nix.go
@@ -1,0 +1,69 @@
+// +build !windows
+
+package discovery
+
+import (
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+const keyWidth = 25
+
+var obtainedUnameInfo bool
+var unameInfo unix.Utsname
+
+func init() {
+	unameInfo = unix.Utsname{}
+	obtainedUnameInfo = false
+}
+
+func getSystemInfo() string {
+	outputLines := []string{
+		getHostnameLine(getHostname),
+		getOsNameLine(getOsName),
+		getOsVersionLine(getOsVersion),
+		getInfoLine("OS Release", getOsRelease),
+		getHardwareTypeLine(getHardwareType),
+	}
+	return strings.Join(outputLines[:], "\n")
+}
+
+// Reference: https://stackoverflow.com/a/53197771
+func getOsVersion() (string, error) {
+	if err := getUnameInfo(); err != nil {
+		return "", err
+	}
+	return string(unameInfo.Version[:]), nil
+}
+
+func getOsRelease() (string, error) {
+	if err := getUnameInfo(); err != nil {
+		return "", err
+	}
+	return string(unameInfo.Release[:]), nil
+}
+
+func getUnameInfo() error {
+	if !obtainedUnameInfo {
+		if err := unix.Uname(&unameInfo); err != nil {
+			return err
+		}
+		obtainedUnameInfo = true
+	}
+	return nil
+}
+
+func getOsName() (string, error) {
+	if err := getUnameInfo(); err != nil {
+		return "", err
+	}
+	return string(unameInfo.Sysname[:]), nil
+}
+
+func getHardwareType() (string, error) {
+	if err := getUnameInfo(); err != nil {
+		return "", err
+	}
+	return string(unameInfo.Machine[:]), nil
+}

--- a/gocat-extensions/execute/native/discovery/system_info_windows.go
+++ b/gocat-extensions/execute/native/discovery/system_info_windows.go
@@ -1,0 +1,68 @@
+// +build windows
+
+package discovery
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+
+	"golang.org/x/sys/windows"
+)
+
+const keyWidth = 26
+
+var versionInfo *windows.OsVersionInfoEx
+
+func getSystemInfo() string {
+	outputLines := []string{
+		getHostnameLine(getHostname),
+		getOsNameLine(getOsName),
+		getOsVersionLine(getOsVersion),
+		getInfoLine("OS Service Pack", getOsServicePack),
+		getHardwareTypeLine(getHardwareType),
+	}
+	return strings.Join(outputLines[:], "\n")
+}
+
+func getOsVersion() (string, error) {
+	getVersionInfo()
+	verMajor := versionInfo.MajorVersion
+	verMinor := versionInfo.MinorVersion
+	buildNumber := versionInfo.BuildNumber
+
+	return fmt.Sprintf("%d.%d, Build %d", verMajor, verMinor, buildNumber), nil
+}
+
+func getOsName() (string, error) {
+	return "Windows", nil
+}
+
+func getOsServicePack() (string, error) {
+	getVersionInfo()
+	servicePackStr := intArrayToStr(versionInfo.CsdVersion[:])
+	if len(servicePackStr) > 0 {
+		return servicePackStr, nil
+	}
+	return "No service pack detected.", nil
+}
+
+func getVersionInfo() {
+	if versionInfo == nil {
+		versionInfo = windows.RtlGetVersion()
+	}
+}
+
+func getHardwareType() (string, error) {
+	return runtime.GOARCH, nil
+}
+
+func intArrayToStr(intArr []uint16) string {
+	var byteSlice []byte
+	for _, v := range intArr {
+		if v > 0 {
+			byteSlice = append(byteSlice, byte(v))
+		}
+	}
+	return string(byteSlice)
+}


### PR DESCRIPTION
## Description
Native golang methods for gathering basic system information, such as hostname, OS name, OS version, OS release (*nix), OS service pack (windows), OS architecture

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Ran on Linux, Windows, and Mac

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
