### PR TITLE
Removing 54ndc47 references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# 54ndc47 (Sandcat)
+# Sandcat Agent Plugin
 [![Basic Agent Build](https://github.com/mitre/sandcat/actions/workflows/go.yml/badge.svg)](https://github.com/mitre/sandcat/actions/workflows/go.yml)
 [![Agent Extensions Build](https://github.com/mitre/sandcat/actions/workflows/sandcatextensions.yml/badge.svg)](https://github.com/mitre/sandcat/actions/workflows/sandcatextensions.yml)
 
 A plugin supplying a default agent to be used in a CALDERA operation.
 
-[Read the full docs](https://caldera.readthedocs.io/en/latest/Plugin-library.html#sandcat-54ndc47)
+[Read the full docs](https://caldera.readthedocs.io/en/latest/Plugin-library.html#sandcat)

--- a/data/abilities/command-and-control/2f34977d-9558-4c12-abad-349716777c6b.yml
+++ b/data/abilities/command-and-control/2f34977d-9558-4c12-abad-349716777c6b.yml
@@ -1,8 +1,8 @@
 ---
 
 - id: 2f34977d-9558-4c12-abad-349716777c6b
-  name: 54ndc47
-  description: A GoLang agent which communicates through the HTTP contact
+  name: Sandcat
+  description: CALDERA's default agent, written in GoLang. Communicates through the HTTP(S) contact by default.
   tactic: command-and-control
   technique:
     attack_id: T1105

--- a/templates/sandcat.html
+++ b/templates/sandcat.html
@@ -1,16 +1,16 @@
 <div>
     <div>
-        <h2>54ndc47</h2>
+        <h2>Sandcat</h2>
         <p class="has-text-weight-bold">
             A coordinated access trojan (CAT)
         </p>
         <p>
-            The 54ndc47 (Sandcat) agent is a program that can easily be deployed on any computer, upon which,
+            The Sandcat agent is a program that can easily be deployed on any computer, upon which,
             will form a persistent connection back, allowing an operator to execute adversary
-            emulation exercises. 54ndc47 communicates to the server via HTTP(S) by default.
+            emulation exercises. Sandcat communicates with the server over HTTP(S) by default.
         </p>
         <p class="has-text-weight-bold">
-            To deploy a 54ndc47 agent, go to the Agents tab.
+            To deploy a Sandcat agent, go to the Agents tab.
         </p>
     </div>
 </div>


### PR DESCRIPTION
## Description
Removing 54ndc47 references in plugin and replacing them with "sandcat".

## Type of change
- [x] This change requires a documentation update

## How Has This Been Tested?
Reran the server and confirmed that the agents deployment menu and sandcat plugin page no longer mention 54ndc47.


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
