### PR TITLE
look only in the payloads dir of plugins when fetching compiled agents

### DIFF
--- a/app/sand_svc.py
+++ b/app/sand_svc.py
@@ -41,7 +41,7 @@ class SandService(BaseService):
                                           output_name=name,
                                           extension_names=extension_names,
                                           compile_target_dir='gocat')
-        return await self.app_svc.retrieve_compiled_file(name, platform)
+        return await self.app_svc.retrieve_compiled_file(name, platform, location='payloads')
 
     async def dynamically_compile_library(self, headers):
         # HTTP headers will specify the file name, platform, and comma-separated list of extension modules to include.
@@ -76,7 +76,7 @@ class SandService(BaseService):
                                               flag_params=default_flag_params,
                                               extension_names=extension_names,
                                               compile_target_dir='gocat/shared')
-        return await self.app_svc.retrieve_compiled_file(name, platform)
+        return await self.app_svc.retrieve_compiled_file(name, platform, location='payloads')
 
     async def load_sandcat_extension_modules(self):
         """


### PR DESCRIPTION
## Description
Look only in the payloads dir of plugins when fetching compiled sandcat payloads. This way, if other plugins have the sandcat.go-windows binary in a different subfolder, the sandcat plugin service will ignore it.


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Tried compiling sandcat.go-windows with another sandcat.go-windows in a different folder structure and made sure those were ignored.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
