### PR TITLE
[VIRTS-4148] Have agent send both stdout and stderr

### DIFF
--- a/gocat-extensions/execute/donut/donut.go
+++ b/gocat-extensions/execute/donut/donut.go
@@ -54,21 +54,17 @@ func (d *Donut) Run(command string, timeout int, info execute.InstructionInfo) (
 
 			total += "STDOUT:\n"
 			total += string(stdoutBytes)
-			total += "\n\n"
 
-			total += "STDERR:\n"
-			total += string(stderrBytes)
-
-			return execute.CommandResults{[]byte(total), execute.SUCCESS_STATUS, fmt.Sprint(pid), executionTimestamp}
+			return execute.CommandResults{[]byte(total), []byte(string(stderrBytes)), execute.SUCCESS_STATUS, fmt.Sprint(pid), executionTimestamp}
 		}
 
 		// Covers the cases where an error was received before the remote thread was created
 		errorBytes := []byte(fmt.Sprintf("Shellcode execution failed. Error message: %s", fmt.Sprint(err)))
-		return execute.CommandResults{errorBytes, execute.ERROR_STATUS, fmt.Sprint(pid), executionTimestamp}
+		return execute.CommandResults{[]byte{}, errorBytes, execute.ERROR_STATUS, fmt.Sprint(pid), executionTimestamp}
 	} else {
 		// Empty payload
 		errorBytes := []byte(fmt.Sprintf("Empty payload: %s", payload))
-		return execute.CommandResults{errorBytes, execute.ERROR_STATUS, "-1", time.Now().UTC()}
+		return execute.CommandResults{[]byte{}, errorBytes, execute.ERROR_STATUS, "-1", time.Now().UTC()}
 	}
 }
 

--- a/gocat-extensions/execute/shellcode/shellcode.go
+++ b/gocat-extensions/execute/shellcode/shellcode.go
@@ -33,9 +33,9 @@ func (s *Shellcode) Run(command string, timeout int, info execute.InstructionInf
 	executionTimestamp := time.Now().UTC()
 	task, pid := Runner(bytes)
 	if task {
-		return execute.CommandResults{[]byte("Shellcode executed successfully."), execute.SUCCESS_STATUS, pid, executionTimestamp}
+		return execute.CommandResults{[]byte("Shellcode executed successfully."), []byte{}, execute.SUCCESS_STATUS, pid, executionTimestamp}
 	}
-	return execute.CommandResults{[]byte("Shellcode execution failed."), execute.ERROR_STATUS, pid, executionTimestamp}
+	return execute.CommandResults{[]byte{}, []byte("Shellcode execution failed."), execute.ERROR_STATUS, pid, executionTimestamp}
 }
 
 func (s *Shellcode) String() string {

--- a/gocat/agent/agent.go
+++ b/gocat/agent/agent.go
@@ -289,7 +289,8 @@ func (a *Agent) runInstructionCommand(instruction map[string]interface{}) map[st
 	// Handle results
 	result := make(map[string]interface{})
 	result["id"] = instruction["id"]
-	result["output"] = commandResults.Result
+	result["output"] = commandResults.StandardOutput
+	result["stderr"] = commandResults.StandardError
 	result["status"] = commandResults.StatusCode
 	result["pid"] = commandResults.Pid
 	result["agent_reported_time"] = getFormattedTimestamp(commandResults.ExecutionTimestamp, "2006-01-02T15:04:05Z")

--- a/gocat/execute/execute.go
+++ b/gocat/execute/execute.go
@@ -37,7 +37,8 @@ type InstructionInfo struct {
 }
 
 type CommandResults struct {
-	Result []byte
+	StandardOutput []byte
+	StandardError []byte
 	StatusCode string
 	Pid string
 	ExecutionTimestamp time.Time
@@ -61,14 +62,14 @@ func RunCommand(info InstructionInfo) (CommandResults) {
 	var commandResults CommandResults
 	decoded, err := base64.StdEncoding.DecodeString(encodedCommand)
 	if err != nil {
-		commandResults = CommandResults{[]byte(fmt.Sprintf("Error when decoding command: %s", err.Error())), ERROR_STATUS, ERROR_STATUS, time.Now().UTC()}
+		commandResults = CommandResults{[]byte{}, []byte(fmt.Sprintf("Error when decoding command: %s", err.Error())), ERROR_STATUS, ERROR_STATUS, time.Now().UTC()}
 	} else {
 		command := string(decoded)
 		missingPaths := checkPayloadsAvailable(onDiskPayloads)
 		if len(missingPaths) == 0 {
 			commandResults = Executors[executor].Run(command, timeout, info)
 		} else {
-			commandResults = CommandResults{[]byte(fmt.Sprintf("Payload(s) not available: %s", strings.Join(missingPaths, ", "))), ERROR_STATUS, ERROR_STATUS, time.Now().UTC()}
+			commandResults = CommandResults{[]byte{}, []byte(fmt.Sprintf("Payload(s) not available: %s", strings.Join(missingPaths, ", "))), ERROR_STATUS, ERROR_STATUS, time.Now().UTC()}
 		}
 	}
 	return commandResults

--- a/gocat/execute/shells/proc.go
+++ b/gocat/execute/shells/proc.go
@@ -105,7 +105,7 @@ func (p *Proc) Run(command string, timeout int, info execute.InstructionInfo) (e
 	if err != nil {
 		errMsg := fmt.Sprintf("[!] Error parsing command line: %s", err.Error())
 		output.VerbosePrint(errMsg)
-		return execute.CommandResults{[]byte(errMsg), execute.ERROR_STATUS, execute.ERROR_PID, p.timeStampGenerator()}
+		return execute.CommandResults{[]byte{}, []byte(errMsg), execute.ERROR_STATUS, execute.ERROR_PID, p.timeStampGenerator()}
 	}
 	output.VerbosePrint(fmt.Sprintf("[*] Starting process %s with args %v", exePath, exeArgs))
 	if exePath == "del" || exePath == "rm" {
@@ -145,6 +145,7 @@ func (p *Proc) UpdateBinary(newBinary string) {
 
 func (p *Proc) deleteFiles(files []string) (execute.CommandResults) {
 	var outputMessages []string
+	var errorMessages []string
 	var msg string
 	var err error
 	status := execute.SUCCESS_STATUS
@@ -154,12 +155,13 @@ func (p *Proc) deleteFiles(files []string) (execute.CommandResults) {
 		if err != nil {
 			msg = fmt.Sprintf("Failed to remove %s: %s", toDelete, err.Error())
 			status = execute.ERROR_STATUS
+			errorMessages = append(errorMessages, msg)
 		} else {
 			msg = fmt.Sprintf("Removed file %s.", toDelete)
+			outputMessages = append(outputMessages, msg)
 		}
-		outputMessages = append(outputMessages, msg)
 	}
-	return execute.CommandResults{[]byte(strings.Join(outputMessages, "\n")), status, p.pidStr, executionTimestamp}
+	return execute.CommandResults{[]byte(strings.Join(outputMessages, "\n")), []byte(strings.Join(errorMessages, "\n")), status, p.pidStr, executionTimestamp}
 }
 
 func runStandardCmd(exePath string, exeArgs []string, timeout int) (execute.CommandResults) {
@@ -170,10 +172,10 @@ func (p *Proc) runBackgroundCmd(exePath string, exeArgs []string) (execute.Comma
 	handle := exec.Command(exePath, append(exeArgs)...)
 	err := p.cmdHandleRunner(handle)
 	if err != nil {
-		return execute.CommandResults{[]byte(err.Error()), execute.ERROR_STATUS, execute.ERROR_PID, p.timeStampGenerator()}
+		return execute.CommandResults{[]byte{}, []byte(err.Error()), execute.ERROR_STATUS, execute.ERROR_PID, p.timeStampGenerator()}
 	}
 	pid := p.cmdHandlePidGetter(handle)
 	pidStr := strconv.Itoa(pid)
 	retMsg := fmt.Sprintf("Executed background process %s with PID %d and args: %s", exePath, pid, strings.Join(exeArgs, ", "))
-	return execute.CommandResults{[]byte(retMsg), execute.SUCCESS_STATUS, pidStr, p.timeStampGenerator()}
+	return execute.CommandResults{[]byte(retMsg), []byte{}, execute.SUCCESS_STATUS, pidStr, p.timeStampGenerator()}
 }


### PR DESCRIPTION
## Description

This PR will send both stdout and stderr results to the server.  stdout is sent as "output" (the previously used field) for compatibility with other agents, while stderr is sent as "stderr".  Link status was NOT effected (i.e., if stderr exists, the link status will be failure).

Pending: https://github.com/mitre/caldera/pull/2662

## Type of change

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested with the new MITRE/Caldera PR [VIRTS-4149] changes, which accounts for this change on the server side.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [N/A] I have made corresponding changes to the documentation - future ticket
- [X] I have added tests that prove my fix is effective or that my feature works
