### PR TITLE
Set username to unknown if failed to fetch rather than terminate agent

### DIFF
--- a/gocat/agent/agent.go
+++ b/gocat/agent/agent.go
@@ -97,7 +97,8 @@ func (a *Agent) Initialize(server string, tunnelConfig *contact.TunnelConfig, gr
 	if userName, err := getUsername(); err == nil {
 		a.username = userName
 	} else {
-		return err
+		output.VerbosePrint(fmt.Sprintf("[-] Failed to find username: %s. Setting to unknown.", err.Error()))
+		a.username = "UNKNOWN"
 	}
 	a.server = server
 	a.upstreamDestAddr = server
@@ -382,6 +383,7 @@ func (a *Agent) AttemptSelectComChannel(requestedChannelConfig map[string]string
 
 // Outputs information about the agent.
 func (a *Agent) Display() {
+	output.VerbosePrint(fmt.Sprintf("username=%s", a.username))
 	output.VerbosePrint(fmt.Sprintf("initial delay=%d", int(a.initialDelay)))
 	output.VerbosePrint(fmt.Sprintf("server=%s", a.server))
 	output.VerbosePrint(fmt.Sprintf("upstream dest addr=%s", a.upstreamDestAddr))


### PR DESCRIPTION
## Description
Implement fix to address https://github.com/mitre/sandcat/issues/417
- Rather than have agent terminate if it fails to fetch the current username, set the username to `UNKNOWN`
- agent will now print out current username in verbose output for tracking purposes

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Compiled and ran agent, verified username printed out correctly

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
